### PR TITLE
test: give each QT3 test set a fresh runner — per-set results depended on run order

### DIFF
--- a/tests/PhoenixmlDb.Conformance.Tests/XQuery/XqtsConformanceTests.cs
+++ b/tests/PhoenixmlDb.Conformance.Tests/XQuery/XqtsConformanceTests.cs
@@ -293,7 +293,15 @@ public class XqtsConformanceTests : IClassFixture<XqtsTestFixture>
             Assert.Skip("W3C QT3 suite not found. Set QT3_TEST_SUITE, or run scripts/fetch-conformance-suites.sh.");
         }
 
-        var testCases = await _fixture.LoadTestSetAsync(category, testSetName);
+        // A FRESH runner per set. The runner accumulates state as it runs — loaded schemas,
+        // registered document URIs, resource mappings, a document store, one engine — and a
+        // shared one carried every set's leftovers into the next. The monolith ran in catalog
+        // order, so that contamination was at least stable; as a theory the sets run in
+        // xunit's order, which follows the assembly PATH, so the same commits scored
+        // differently from two checkouts: method-html 40/64 from one, 36/64 from another,
+        // and 49/64 alone. A set's result must be a property of the set. (BUGS.md #44, incident 12)
+        var runner = _fixture.CreateRunner();
+        var testCases = await runner.LoadTestSetByNameAsync(testSetName, TestContext.Current.CancellationToken);
         _output.WriteLine($"Running {testCases.Count} tests from {category}/{testSetName}");
 
         var passed = 0;
@@ -301,7 +309,7 @@ public class XqtsConformanceTests : IClassFixture<XqtsTestFixture>
 
         foreach (var testCase in testCases)
         {
-            var result = await _fixture.Runner.RunTestAsync(testCase, TestContext.Current.CancellationToken);
+            var result = await runner.RunTestAsync(testCase, TestContext.Current.CancellationToken);
             if (result.Passed)
             {
                 passed++;
@@ -410,9 +418,19 @@ public sealed class XqtsTestFixture : IAsyncLifetime
         config.SkipTests.Add("fn-transform"); // Requires XSLT support in fn:transform
         config.SkipTests.Add("fn-parse-xml-fragment"); // DTD handling
 
+        _config = config;
         Runner = new XqtsTestRunner(_testDataPath, config);
         return ValueTask.CompletedTask;
     }
+
+    private XqtsConfiguration _config = null!;
+
+    /// <summary>
+    /// A runner with no history. <see cref="Runner"/> is shared and accumulates state across
+    /// everything it runs, so anything whose result must not depend on what ran before it —
+    /// the per-set theory — takes one of these instead.
+    /// </summary>
+    public XqtsTestRunner CreateRunner() => new(_testDataPath, _config);
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 


### PR DESCRIPTION
Fixes BUGS.md #44, incident 12: QT3 per-set results depended on the order the sets ran in.

## The defect

`XqtsTestRunner` accumulates state as it runs: one `QueryEngine`, a document store and cache, the
loaded-schema set, registered document URIs, and resource mappings. The per-set theory (`174a3d8`)
shared **one** runner across all 428 sets via `IClassFixture`, so every set inherited its
predecessors' leftovers.

The monolith ran in catalog order, so the contamination there was stable and invisible. The theory
runs in xunit's order, which follows the assembly path, so **the same commits checked out in two
directories disagreed on six sets**. Re-run alone, each of those sets was identical on both commits:

    ser/method-html     40/64 in one checkout, 36/64 in the other, 49/64 alone

## The fix

The theory now loads and runs each set on its own runner, via `XqtsTestFixture.CreateRunner()`.
Within a set, cases still share a runner, in catalog order. The shared fixture runner is kept for
the smoke tests and the monolith.

## Verified by varying only the order

Two worktrees at different paths, with the same xslt commit and the same xquery commit. Their set
orders genuinely differ: one starts at `fn/fn-unparsed-text-lines`, the other at
`prod/prod-BaseURIDecl`.

| | cases | per-set differences |
|---|---|---|
| checkout A | 29,507 / 31,414 | — |
| checkout B | 29,507 / 31,414 | **0** |

Every previously contaminated set now scores its isolated value: `method-html` 49, `method-xhtml` 27,
`prod-SchemaImport` 29, `prod-ValidateExpr` 5, `prod-CastableExpr` 858.

**The shared state was a net loss**, not just noise: fresh runners score +126 cases (29,381 → 29,507)
at the same ~78 s wall clock.

No QT3 per-set baseline or published QT3 figure should predate this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn
