### PR TITLE
fix: seven error sites raised no code or the wrong one — +43 W3C cases, 0 lost

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
@@ -1044,6 +1044,40 @@ internal sealed partial class DefaultXsltExecutionContext
     }
 
 
+    /// <summary>
+    /// The named template <paramref name="name"/> denotes, or null. One lookup for both
+    /// xsl:call-template and the initial-template checks in the transform engine, so that
+    /// "does this template exist" cannot disagree with "can this template be called".
+    /// </summary>
+    internal XsltTemplate? FindNamedTemplate(QName name)
+    {
+        if (_stylesheet.NamedTemplates.TryGetValue(name, out var template))
+            return template;
+
+        // The id-keyed lookup above is the fast path and is correct for a name the parser
+        // interned. It misses for a QName built at runtime by fn:QName(), which carries a
+        // hash-based NamespaceId that never equals the parser's id for the same URI - so
+        // fn:transform with a namespaced initial-template could not find its entry point,
+        // and reported the local name of a template it had just failed to qualify.
+        foreach (var (candidate, decl) in _stylesheet.NamedTemplates)
+        {
+            if (QNameNamespaces.SameExpandedName(candidate, name, ResolveViaStylesheet))
+                return decl;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves an interned namespace id back to a URI. That needs the table that interned it.
+    /// The node store does not have it - these ids come from the stylesheet parser - but the
+    /// stylesheet keeps its own prefix-to-URI map, and the parsed QName kept its prefix.
+    /// </summary>
+    private string? ResolveViaStylesheet(QName q)
+        => _nodeStore?.GetNamespaceUri(q.Namespace)
+        ?? (!string.IsNullOrEmpty(q.Prefix)
+            && _stylesheet.Namespaces.TryGetValue(q.Prefix, out var declared)
+                ? declared : null);
+
     public override async ValueTask CallTemplateAsync(QName name, List<XsltWithParam> withParams)
     {
         // Trace: call-template
@@ -1069,39 +1103,21 @@ internal sealed partial class DefaultXsltExecutionContext
             if (template == null)
                 throw Error("XTDE3058: xsl:original invoked but no overridden template is available");
         }
-        else if (!_stylesheet.NamedTemplates.TryGetValue(name, out template))
+        else
         {
-            // The id-keyed lookup above is the fast path and is correct for a name the parser
-            // interned. It misses for a QName built at runtime by fn:QName(), which carries a
-            // hash-based NamespaceId that never equals the parser's id for the same URI - so
-            // fn:transform with a namespaced initial-template could not find its entry point,
-            // and reported the local name of a template it had just failed to qualify.
-            // Resolving an interned id back to a URI needs the table that interned it. The node
-            // store does not have it - these ids come from the stylesheet parser - but the
-            // stylesheet keeps its own prefix-to-URI map, and the parsed QName kept its prefix.
-            string? ResolveViaStylesheet(QName q)
-                => _nodeStore?.GetNamespaceUri(q.Namespace)
-                ?? (!string.IsNullOrEmpty(q.Prefix)
-                    && _stylesheet.Namespaces.TryGetValue(q.Prefix, out var declared)
-                        ? declared : null);
-
-            foreach (var (candidate, decl) in _stylesheet.NamedTemplates)
-            {
-                if (QNameNamespaces.SameExpandedName(candidate, name, ResolveViaStylesheet))
-                {
-                    template = decl;
-                    break;
-                }
-            }
-
+            template = FindNamedTemplate(name);
             if (template == null)
             {
+                // XTSE0650 is a static error — a call-template naming no visible template — that
+                // this engine detects when the call executes. The message used to carry no code
+                // at all. (An INITIAL template that does not exist is XTDE0040 instead; the
+                // transform engine checks that before it gets here.)
                 // Name the namespace too. The old message quoted only the local part, which is
                 // exactly the information that does not help when the namespace is the problem.
                 var uri = QNameNamespaces.UriOf(name, ResolveViaStylesheet);
                 throw Error(uri.Length > 0
-                    ? $"Named template 'Q{{{uri}}}{name.LocalName}' not found"
-                    : $"Named template '{name.LocalName}' not found");
+                    ? $"XTSE0650: Named template 'Q{{{uri}}}{name.LocalName}' not found"
+                    : $"XTSE0650: Named template '{name.LocalName}' not found");
             }
         }
 
@@ -1174,7 +1190,11 @@ internal sealed partial class DefaultXsltExecutionContext
                 }
                 else if (param.Required)
                 {
-                    throw Error($"Required parameter ${param.Name.LocalName} not supplied");
+                    // Under xsl:call-template a missing required non-tunnel parameter is the
+                    // STATIC error XTSE0690 (the call site is visible); a tunnel parameter can
+                    // only be known missing at run time, XTDE0700. This message had no code.
+                    var code = param.Tunnel ? "XTDE0700" : "XTSE0690";
+                    throw Error($"{code}: Required parameter ${param.Name.LocalName} not supplied");
                 }
                 else if (param.Select != null)
                 {

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Variables.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Variables.cs
@@ -1373,7 +1373,10 @@ internal sealed partial class DefaultXsltExecutionContext
 
         if (instruction.Required)
         {
-            throw Error($"Required parameter ${instruction.Name.LocalName} not supplied");
+            // Reached when a template is entered by apply-templates / next-match /
+            // apply-imports without the parameter: XTDE0700. Its siblings in
+            // DefaultXsltExecutionContext.Templates carried the code; this one did not.
+            throw Error($"XTDE0700: Required parameter ${instruction.Name.LocalName} not supplied");
         }
 
         object? value;

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Expressions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Expressions.cs
@@ -408,7 +408,7 @@ public sealed partial class StylesheetParser
             var closeBrace = FindMatchingBrace(value, openBrace);
             if (closeBrace < 0)
             {
-                throw new XsltException("Unmatched '{' in attribute value template", GetSourceLocation(context));
+                throw new XsltException("XTSE0350: Unmatched '{' in attribute value template", GetSourceLocation(context));
             }
 
             var expr = value[(openBrace + 1)..closeBrace];

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.NodeIO.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.NodeIO.cs
@@ -194,9 +194,17 @@ public sealed partial class StylesheetParser
 
         // Recursion key: the absolute URI for HTTP imports, the canonical full path for file imports.
         var recursionKey = isHttp ? resolvedUri!.AbsoluteUri : Path.GetFullPath(resolvedPath!);
+        // The element that closes the cycle decides the code: XTSE0180 for a module that
+        // includes itself, XTSE0210 for one that imports itself. This method serves both,
+        // and reported XTSE0210 for include cycles too.
         if (!_loadedStylesheets.Add(recursionKey))
-            throw new XsltException($"XTSE0210: Stylesheet module '{href}' directly or indirectly imports itself",
-                GetSourceLocation(element));
+        {
+            throw element.Name.LocalName == "include"
+                ? new XsltException($"XTSE0180: Stylesheet module '{href}' directly or indirectly includes itself",
+                    GetSourceLocation(element))
+                : new XsltException($"XTSE0210: Stylesheet module '{href}' directly or indirectly imports itself",
+                    GetSourceLocation(element));
+        }
 
         // Resource policy: check import access and try custom resolver
         string? policyResolvedXml = null;

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
@@ -1169,7 +1169,19 @@ public sealed partial class StylesheetParser
                 : new XsltSequenceConstructor { Instructions = instructions };
         }
 
-        throw new XsltException($"Unknown XSLT instruction: {element.Name.LocalName}", location);
+        // Not "unknown": most of what lands here is a real XSLT element in the wrong place —
+        // a declaration (xsl:key, xsl:template, xsl:include) or a child-only element (xsl:sort,
+        // xsl:with-param) used as an instruction. The message used to say "Unknown XSLT
+        // instruction: include" with no code, naming the wrong thing and matching nothing.
+        // xsl:include and xsl:import have their own codes for "must be top-level".
+        var name = element.Name.LocalName;
+        var code = name switch
+        {
+            "include" => "XTSE0170",
+            "import" => "XTSE0190",
+            _ => "XTSE0010",
+        };
+        throw new XsltException($"{code}: xsl:{name} is not allowed in a sequence constructor", location);
     }
 
 

--- a/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
@@ -342,6 +342,8 @@ public sealed class XsltTransformEngine
             // final — whether declared inline or raised by xsl:expose — is eligible as
             // an entry point. See W3C decl/package package-001a/001b, decl/accept
             // accept-001a.
+            if (context.FindNamedTemplate(initialTemplate.Value) is null)
+                throw InitialTemplateNotFound(initialTemplate.Value);
             if (_stylesheet.IsPackage
                 && _stylesheet.NamedTemplates.TryGetValue(initialTemplate.Value, out var tmpl)
                 && tmpl.VisibilityAttr is not ("public" or "final"))
@@ -1003,6 +1005,8 @@ public sealed class XsltTransformEngine
             // XTDE0040: Check that initial template is public (in packages)
             // In TransformRawAsync (used by fn:transform), check all templates since
             // fn:transform targets specific packages — xsl:expose visibility is enforced.
+            if (context.FindNamedTemplate(initialTemplate) is null)
+                throw InitialTemplateNotFound(initialTemplate);
             if (_stylesheet.IsPackage
                 && _stylesheet.NamedTemplates.TryGetValue(initialTemplate, out var rawTmpl)
                 && rawTmpl.VisibilityAttr is not ("public" or "final"))
@@ -1111,6 +1115,15 @@ public sealed class XsltTransformEngine
         Xdm.Nodes.XdmDocument d => d.Children,
         _ => System.Array.Empty<NodeId>(),
     };
+
+    /// <summary>
+    /// XTDE0040 for an initial template that does not exist. All three entry points (Transform,
+    /// TransformRaw and the sequence variant) checked that an initial template was PUBLIC and
+    /// none checked that it EXISTED, so a missing one fell through to xsl:call-template's
+    /// lookup and surfaced as that instruction's error instead of the invocation's.
+    /// </summary>
+    private static XsltException InitialTemplateNotFound(QName name)
+        => new($"XTDE0040: Initial template '{name.LocalName}' does not exist in the stylesheet");
 
     /// <summary>
     /// Wraps any <see cref="Xdm.Nodes.XdmElement"/> / <see cref="Xdm.Nodes.XdmDocument"/>
@@ -1317,6 +1330,8 @@ public sealed class XsltTransformEngine
             {
                 var initialTemplate = options.InitialTemplate
                     ?? _stylesheet.NamedTemplates.Keys.First(k => k.LocalName == "initial-template");
+                if (context.FindNamedTemplate(initialTemplate) is null)
+                    throw InitialTemplateNotFound(initialTemplate);
                 if (_stylesheet.IsPackage
                     && _stylesheet.NamedTemplates.TryGetValue(initialTemplate, out var rawTmpl)
                     && rawTmpl.VisibilityAttr is not ("public" or "final"))


### PR DESCRIPTION
First batch against #13, the wrong-error-code backlog. **+43 W3C cases, zero lost.**

## Method, and what the data turned out to say

Grouping the 217 `[wrong-error-code]` failures by (expected, actual) gives **133 distinct pairs**: a
long tail, not a handful of wrong constants. Grouping by the **actual** message instead points
straight at throw sites. These seven sites account for the 43:

| site | was | now |
|---|---|---|
| XSLT element not allowed in a sequence constructor | `Unknown XSLT instruction: include`, no code | XTSE0010, or XTSE0170 / XTSE0190 for include / import |
| self-inclusion | XTSE0210 (the *import* code) | XTSE0180 for `xsl:include` |
| `call-template` to no visible template | no code | XTSE0650 |
| initial template that doesn't exist | fell through to the row above | XTDE0040 |
| `call-template` missing a required param | no code | XTSE0690 (XTDE0700 if tunnel) |
| `BindParamAsync` missing a required param | no code | XTDE0700 |
| AVT with an unmatched `{` | no code | XTSE0350 |

Two of these are the asymmetric-pair shape:

- `BindParamAsync`'s siblings carried XTDE0700 and it did not.
- All three initial-template entry points checked that the template was *public*, and none checked
  that it *existed*. That check now goes through `FindNamedTemplate`, extracted from
  `CallTemplateAsync` with its namespace-aware matching intact, so "does it exist" can't disagree
  with "can it be called".

## Measured

Two full 11-chunk sweeps from the same checkout, with and without this change:
**10,083 → 10,126 / 10,630**. Per case: 43 newly passing, **0 newly failing**, and no set went down.
`misc/error` went 438 → 466. The rest is spread across `call-template`, `context-item`, `package`,
`initial-template`, `iterate`, `merge`, `function`, `namespace-alias`, `character-map`, `version`
and `expand-text`.

## Unit suite

1482/1484. The one failure, in `StreamingCancellationTests`, also fails on `main` without this
change (2 of 4 there, 1 of 4 here) and is deterministic on a fast machine. Those tests cancel at 3 s
and assume the transform is still running, and here it finishes in about 2 s. CI's slower runners
hide that. It'll be fixed separately.

Refs #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn
