### PR TITLE
fix: package-version values and ranges were never validated — +11 W3C cases

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/PackageVersionSyntax.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/PackageVersionSyntax.cs
@@ -1,0 +1,115 @@
+using System.Text;
+
+namespace PhoenixmlDb.Xslt.Engine;
+
+/// <summary>
+/// Lexical rules for package versions and version ranges (XSLT 3.0 §3.5.1). An invalid value
+/// is a static error, XTSE0020. Neither attribute was validated: a malformed
+/// <c>xsl:package/@package-version</c> was accepted as-is, and a malformed
+/// <c>xsl:use-package/@package-version</c> simply matched nothing and surfaced as "package not
+/// found" (XTDE3052) — an error about the catalog, for a mistake in the stylesheet.
+/// </summary>
+internal static class PackageVersionSyntax
+{
+    /// <summary>
+    /// <c>PackageVersion ::= NumericPart ("-" NamePart)?</c>, where NumericPart is one or more
+    /// integers separated by dots and NamePart is an NCName.
+    /// </summary>
+    public static bool IsValidVersion(string value)
+    {
+        var dash = value.IndexOf('-', StringComparison.Ordinal);
+        if (!IsNumericPart(dash < 0 ? value : value[..dash]))
+            return false;
+        return dash < 0 || IsNCName(value[(dash + 1)..]);
+    }
+
+    /// <summary>
+    /// A version range, in exactly the forms <c>StylesheetParser.VersionMatches</c> understands:
+    /// <c>*</c>; a comma-separated list of <c>V</c>, <c>V+</c>, <c>N.*</c>, <c>to V</c>,
+    /// <c>V to V</c> and <c>V to</c>. Kept in step with the matcher deliberately — a range this
+    /// accepts but the matcher does not would silently match nothing.
+    /// </summary>
+    public static bool IsValidRange(string value)
+    {
+        var range = value.Trim();
+        if (range == "*")
+            return true;
+        foreach (var raw in range.Split(','))
+        {
+            var part = raw.Trim();
+            if (part.Length == 0)
+                return false;
+            if (part.StartsWith("to ", StringComparison.Ordinal))
+            {
+                if (!IsVersionOrPrefix(part[3..].Trim()))
+                    return false;
+                continue;
+            }
+            var to = part.IndexOf(" to ", StringComparison.Ordinal);
+            if (to >= 0)
+            {
+                var high = part[(to + 4)..].Trim();
+                if (!IsValidVersion(part[..to].Trim()) || (high.Length > 0 && !IsVersionOrPrefix(high)))
+                    return false;
+                continue;
+            }
+            if (part.EndsWith(" to", StringComparison.Ordinal))
+            {
+                if (!IsValidVersion(part[..^3].Trim()))
+                    return false;
+                continue;
+            }
+            if (!IsVersionOrPrefix(part.EndsWith('+') ? part[..^1] : part))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsVersionOrPrefix(string value)
+        => value.EndsWith(".*", StringComparison.Ordinal) ? IsNumericPart(value[..^2]) : IsValidVersion(value);
+
+    private static bool IsNumericPart(string value)
+    {
+        if (value.Length == 0)
+            return false;
+        foreach (var part in value.Split('.'))
+        {
+            if (part.Length == 0)
+                return false;
+            foreach (var c in part)
+                if (!char.IsAsciiDigit(c))
+                    return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// NCName by XML 1.0 5th-edition code-point ranges. By code point, not by UTF-16 unit: a
+    /// supplementary character is a valid NameStartChar in [#x10000-#xEFFFF] and invalid above
+    /// it, and a char-based test cannot tell U+F00DC (private use, invalid) from U+10000.
+    /// </summary>
+    private static bool IsNCName(string value)
+    {
+        if (value.Length == 0)
+            return false;
+        var first = true;
+        foreach (var rune in value.EnumerateRunes())
+        {
+            if (first ? !IsNameStartChar(rune.Value) : !IsNameChar(rune.Value))
+                return false;
+            first = false;
+        }
+        return true;
+    }
+
+    private static bool IsNameStartChar(int c) =>
+        c is (>= 'A' and <= 'Z') or '_' or (>= 'a' and <= 'z')
+            or (>= 0xC0 and <= 0xD6) or (>= 0xD8 and <= 0xF6) or (>= 0xF8 and <= 0x2FF)
+            or (>= 0x370 and <= 0x37D) or (>= 0x37F and <= 0x1FFF) or (>= 0x200C and <= 0x200D)
+            or (>= 0x2070 and <= 0x218F) or (>= 0x2C00 and <= 0x2FEF) or (>= 0x3001 and <= 0xD7FF)
+            or (>= 0xF900 and <= 0xFDCF) or (>= 0xFDF0 and <= 0xFFFD) or (>= 0x10000 and <= 0xEFFFF);
+
+    private static bool IsNameChar(int c) =>
+        IsNameStartChar(c) || c is '-' or '.' or (>= '0' and <= '9') or 0xB7
+            or (>= 0x300 and <= 0x36F) or (>= 0x203F and <= 0x2040);
+}

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
@@ -100,6 +100,14 @@ public sealed partial class StylesheetParser
             throw new XsltException("XTSE0090: The 'package-version' attribute is not allowed on xsl:stylesheet/xsl:transform (only on xsl:package)",
                 GetSourceLocation(element));
 
+        if (isPackage && element.Attribute("package-version") is { } packageVersionAttr
+            && packageVersionAttr.Annotation<UnevaluatedShadowValue>() is null
+            && !PackageVersionSyntax.IsValidVersion(packageVersionAttr.Value.Trim()))
+            throw new XsltException(
+                $"XTSE0020: package-version '{packageVersionAttr.Value}' is not a valid package version " +
+                "(integers separated by dots, optionally followed by '-' and an NCName)",
+                GetSourceLocation(element));
+
         var declaredModesAttr = element.Attribute("declared-modes");
         // For xsl:package, declared-modes defaults to true; for xsl:stylesheet, defaults to false
         var declaredModes = isPackage;
@@ -871,6 +879,10 @@ public sealed partial class StylesheetParser
             ?? throw new XsltException("XTSE0010: xsl:use-package requires a 'name' attribute",
                 GetSourceLocation(element));
         var packageVersion = element.Attribute("package-version")?.Value;
+        if (packageVersion != null && !PackageVersionSyntax.IsValidRange(packageVersion))
+            throw new XsltException(
+                $"XTSE0020: package-version '{packageVersion}' on xsl:use-package is not a valid version range",
+                GetSourceLocation(element));
 
         // Resolve the package file from the catalog
         if (_packageCatalog == null || !_packageCatalog.TryGetValue(packageName, out var packageEntries))

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
@@ -2966,6 +2966,19 @@ public sealed partial class StylesheetParser
 
 
     /// <summary>
+    /// Annotates an attribute produced from a shadow attribute whose static expression this
+    /// parser could not evaluate (it evaluates only a subset of XPath statically — not
+    /// <c>doc('')</c>, not <c>system-property()</c> inside <c>replace()</c>). The unevaluable part
+    /// is dropped, so the attribute holds a value the stylesheet never asked for; a validator
+    /// that judged it would report the parser's gap as the author's error.
+    /// </summary>
+    internal sealed class UnevaluatedShadowValue
+    {
+        public static readonly UnevaluatedShadowValue Instance = new();
+        private UnevaluatedShadowValue() { }
+    }
+
+    /// <summary>
     /// Resolves XSLT 3.0 shadow attributes (section 3.6.2).
     /// Shadow attributes use the form _foo="{$param}" where the value is evaluated using
     /// static parameters, and the result replaces the real attribute foo.
@@ -3109,10 +3122,12 @@ public sealed partial class StylesheetParser
             foreach (var shadow in shadowAttrs)
             {
                 var realName = shadow.Name.LocalName[1..]; // Remove leading underscore
-                var value = ResolveShadowValue(shadow.Value, staticParams);
+                var value = ResolveShadowValue(shadow.Value, staticParams, out var complete);
 
                 // Set the real attribute (overriding any existing value)
                 element.SetAttributeValue(realName, value);
+                if (!complete)
+                    element.Attribute(realName)!.AddAnnotation(UnevaluatedShadowValue.Instance);
 
                 // Remove the shadow attribute
                 shadow.Remove();
@@ -3128,7 +3143,14 @@ public sealed partial class StylesheetParser
 
 
     private static string ResolveShadowValue(string template, Dictionary<string, string> staticParams)
+        => ResolveShadowValue(template, staticParams, out _);
+
+    // `complete` is false when some expression in the template could not be evaluated here
+    // and was dropped: the result is then not the value the stylesheet asked for, and must
+    // not be validated as if it were.
+    private static string ResolveShadowValue(string template, Dictionary<string, string> staticParams, out bool complete)
     {
+        complete = true;
         // Process static AVT: {$name} → variable value, {{/}} → literal {/}, {...} → expression result
         var result = new System.Text.StringBuilder();
         var i = 0;
@@ -3166,6 +3188,8 @@ public sealed partial class StylesheetParser
                         var evaluated = EvaluateShadowExpression(expr, staticParams);
                         if (evaluated != null)
                             result.Append(evaluated);
+                        else
+                            complete = false;
                     }
                     i = end + 1;
                     continue;


### PR DESCRIPTION
Batch 2 against #13. **+11 W3C cases.**

`xsl:package/@package-version` and `xsl:use-package/@package-version` were never validated. A
malformed version was accepted, and then failed later as XTDE0040. A malformed range matched nothing
and surfaced as XTDE3052 "package not found", an error about the catalog for a mistake in the
stylesheet. Both are now XTSE0020 (XSLT 3.0 §3.5.1).

- **The range grammar mirrors the existing matcher** (`VersionMatches`), so validator and matcher
  can't disagree.
- **The NCName suffix is checked by code point**, using the XML 1.0 5th-edition ranges. A char-based
  check can't reject U+F00DC (private use) while accepting valid supplementary characters.
- **Shadow attributes:** the parser silently *dropped* static expressions it couldn't evaluate.
  Validating that leftover rejected two valid stylesheets, so such attributes are now annotated and
  skipped. That costs `package-version-910`, which had been passing by coincidence. 909, 910, 010
  and 011 need static expressions evaluated by the real XPath engine; that's a follow-up.

## Measured

Same-checkout A/B, full sweep: **10,127 → 10,137 / 10,630**.

- 11 newly passing: `package-version-902..908` and `use-package-291..294`
- 1 newly failing: `call-template-1002`, the known flaky deep-recursion case, which flickers with and
  without this change

The unit suite shows only the pre-existing `StreamingCancellationTests` failure (BUGS.md #46).

Refs #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn
