### PR TITLE
fix: error-code, XTTE3360, required attributes and NCName checks — +18 W3C cases, 0 lost

### DIFF
--- a/scripts/conformance-baseline.tsv
+++ b/scripts/conformance-baseline.tsv
@@ -424,7 +424,7 @@ tests/attr/expand-text/_expand-text-test-set.xml	58	59
 tests/attr/match/_match-test-set.xml	179	179
 tests/attr/mode/_mode-test-set.xml	153	168
 tests/attr/package-version/_package-version-test-set.xml	33	35
-tests/attr/select/_select-test-set.xml	155	157
+tests/attr/select/_select-test-set.xml	156	157
 tests/attr/shadow/_shadow-test-set.xml	8	8
 tests/attr/static/_static-test-set.xml	46	50
 tests/attr/streamable/_streamable-test-set.xml	59	64
@@ -435,7 +435,7 @@ tests/attr/validation/_validation-test-set.xml	6	6
 tests/attr/version/_version-test-set.xml	31	33
 tests/attr/xpath-default-namespace/_xpath-default-namespace-test-set.xml	22	22
 tests/decl/accept/_accept-test-set.xml	27	50
-tests/decl/accumulator/_accumulator-test-set.xml	81	103
+tests/decl/accumulator/_accumulator-test-set.xml	82	103
 tests/decl/attribute-set/_attribute-set-test-set.xml	48	49
 tests/decl/character-map/_character-map-test-set.xml	28	29
 tests/decl/context-item/_context-item-test-set.xml	24	31
@@ -444,7 +444,7 @@ tests/decl/global-context-item/_global-context-item-test-set.xml	12	14
 tests/decl/import/_import-test-set.xml	40	40
 tests/decl/include/_include-test-set.xml	13	15
 tests/decl/namespace-alias/_namespace-alias-test-set.xml	26	26
-tests/decl/output/_output-test-set.xml	213	222
+tests/decl/output/_output-test-set.xml	214	222
 tests/decl/override/_override-test-set.xml	83	100
 tests/decl/package/_package-test-set.xml	58	72
 tests/decl/param/_param-test-set.xml	28	31
@@ -512,7 +512,7 @@ tests/insn/for-each-group/_for-each-group-test-set.xml	80	81
 tests/insn/iterate/_iterate-test-set.xml	38	44
 tests/insn/lre/_lre-test-set.xml	34	35
 tests/insn/merge/_merge-test-set.xml	86	104
-tests/insn/message/_message-test-set.xml	36	45
+tests/insn/message/_message-test-set.xml	43	45
 tests/insn/next-match/_next-match-test-set.xml	39	40
 tests/insn/number/_number-test-set.xml	264	267
 tests/insn/on-empty/_on-empty-test-set.xml	72	72
@@ -530,7 +530,7 @@ tests/misc/built-in-templates/_built-in-templates-test-set.xml	5	5
 tests/misc/catalog/_catalog-test-set.xml	2	4
 tests/misc/collations/_collations-test-set.xml	42	43
 tests/misc/docbook/_docbook-test-set.xml	2	4
-tests/misc/error/_error-test-set.xml	466	507
+tests/misc/error/_error-test-set.xml	472	507
 tests/misc/forwards/_forwards-test-set.xml	23	23
 tests/misc/initial-function/_initial-function-test-set.xml	33	35
 tests/misc/initial-mode/_initial-mode-test-set.xml	5	5
@@ -633,7 +633,7 @@ tests/type/arrays/_arrays-test-set.xml	59	62
 tests/type/boolean/_boolean-test-set.xml	111	112
 tests/type/date/_date-test-set.xml	128	130
 tests/type/maps/_maps-test-set.xml	48	50
-tests/type/namespace/_namespace-test-set.xml	181	187
+tests/type/namespace/_namespace-test-set.xml	183	187
 tests/type/node/_node-test-set.xml	31	31
 tests/type/string/_string-test-set.xml	135	136
 tests/type/type/_type-test-set.xml	57	58

--- a/src/PhoenixmlDb.Xslt/Ast/XsltMessage.cs
+++ b/src/PhoenixmlDb.Xslt/Ast/XsltMessage.cs
@@ -17,6 +17,12 @@ public sealed class XsltMessage : XsltInstruction
     public XsltAttributeValueTemplate? TerminateAvt { get; init; }
     public string? ErrorCode { get; init; }
 
+    /// <summary>The error-code attribute as an AVT; evaluated only when the message terminates.</summary>
+    public XsltAttributeValueTemplate? ErrorCodeAvt { get; init; }
+
+    /// <summary>Namespaces in scope on the xsl:message, for resolving a prefixed error-code.</summary>
+    public IReadOnlyDictionary<string, string>? ErrorCodeNamespaces { get; init; }
+
     public override T Accept<T>(IXsltInstructionVisitor<T> visitor) => visitor.VisitMessage(this);
 
     public override async ValueTask ExecuteAsync(XsltExecutionContext context)

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Construction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Construction.cs
@@ -132,7 +132,7 @@ internal sealed partial class DefaultXsltExecutionContext
                 System.Xml.XmlConvert.VerifyNCName(name);
             }
         }
-        catch (System.Xml.XmlException)
+        catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
         {
             throw Error($"XTDE0820: The effective value of the 'name' attribute of xsl:element ('{name}') is not a valid QName");
         }
@@ -449,7 +449,7 @@ internal sealed partial class DefaultXsltExecutionContext
                 System.Xml.XmlConvert.VerifyNCName(name);
             }
         }
-        catch (System.Xml.XmlException)
+        catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
         {
             throw Error($"XTDE0850: The effective value of the 'name' attribute of xsl:attribute ('{name}') is not a valid QName");
         }
@@ -789,7 +789,7 @@ internal sealed partial class DefaultXsltExecutionContext
         {
             try
             { System.Xml.XmlConvert.VerifyNCName(prefix); }
-            catch (System.Xml.XmlException)
+            catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
             {
                 throw Error($"XTDE0920: The effective value of the 'name' attribute of xsl:namespace ('{prefix}') is not a valid NCName");
             }

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
@@ -1013,7 +1013,7 @@ internal sealed partial class DefaultXsltExecutionContext
                         {
                             System.Xml.XmlConvert.VerifyNCName(formatName);
                         }
-                        catch (System.Xml.XmlException)
+                        catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
                         {
                             throw Error($"XTDE1460: The format attribute of xsl:result-document ('{formatName}') is not a valid EQName");
                         }

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -2663,7 +2663,7 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
         // XTDE0890: The name must be a valid NCName and a valid PITarget
         try
         { System.Xml.XmlConvert.VerifyNCName(name); }
-        catch (System.Xml.XmlException)
+        catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
         {
             throw Error($"XTDE0890: The effective value of the 'name' attribute of xsl:processing-instruction ('{name}') is not a valid NCName");
         }
@@ -3263,10 +3263,60 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
 
         if (shouldTerminate)
         {
-            // XTMM9000 is the code the spec assigns to a terminated transformation. It was the
-            // only throw in this method without one — XTDE0030 immediately above has carried its
-            // code all along.
-            throw Error($"XTMM9000: Transformation terminated: {message}");
+            // XTMM9000 is the code the spec assigns to a terminated transformation — unless the
+            // instruction names its own with error-code, which was parsed and then never read.
+            var code = instruction.ErrorCodeAvt is null
+                ? "XTMM9000"
+                : await ResolveMessageErrorCodeAsync(instruction).ConfigureAwait(false);
+            throw Error($"{code}: Transformation terminated: {message}");
+        }
+    }
+
+
+    /// <summary>
+    /// Evaluates xsl:message/@error-code to the code the terminated transformation reports: a
+    /// standard code (the xqt-errors namespace) as its bare local name, like every other code
+    /// this engine raises, and any other as an EQName, Q{uri}local — Q{} for no namespace.
+    /// The attribute is an AVT whose value is an EQName or a lexical QName, prefixed or not; an
+    /// unprefixed one is in no namespace. A value that is not a valid QName, or whose prefix is
+    /// not in scope, falls back to XTMM9000 (W3C message-0406).
+    /// </summary>
+    private async ValueTask<string> ResolveMessageErrorCodeAsync(XsltMessage instruction)
+    {
+        const string ErrNs = "http://www.w3.org/2005/xqt-errors";
+        const string Fallback = "XTMM9000";
+        var value = (await EvaluateAvtAsync(instruction.ErrorCodeAvt!).ConfigureAwait(false)).Trim();
+        string uri, local;
+        if (value.StartsWith("Q{", StringComparison.Ordinal) && value.IndexOf('}', StringComparison.Ordinal) is var close and > 1)
+        {
+            uri = value[2..close];
+            local = value[(close + 1)..];
+        }
+        else if (value.IndexOf(':', StringComparison.Ordinal) is var colon and > 0)
+        {
+            local = value[(colon + 1)..];
+            if (!IsNCName(value[..colon])
+                || instruction.ErrorCodeNamespaces is null
+                || !instruction.ErrorCodeNamespaces.TryGetValue(value[..colon], out uri!))
+                return Fallback;
+        }
+        else
+        {
+            uri = "";
+            local = value;
+        }
+        if (!IsNCName(local))
+            return Fallback;
+        return uri == ErrNs ? local : $"Q{{{uri}}}{local}";
+
+        static bool IsNCName(string s)
+        {
+            if (s.Length == 0 || !(char.IsLetter(s[0]) || s[0] == '_'))
+                return false;
+            foreach (var c in s)
+                if (!(char.IsLetterOrDigit(c) || c is '_' or '-' or '.'))
+                    return false;
+            return true;
         }
     }
 

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Construction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Construction.cs
@@ -242,21 +242,7 @@ public sealed partial class StylesheetParser
         }
 
         // Capture in-scope namespace bindings for prefix resolution at runtime
-        var inScopeNamespaces = new Dictionary<string, string>();
-        foreach (var nsAttr in element.Attributes().Where(a => a.IsNamespaceDeclaration))
-        {
-            var prefix = nsAttr.Name.LocalName == "xmlns" ? "" : nsAttr.Name.LocalName;
-            inScopeNamespaces[prefix] = nsAttr.Value;
-        }
-        // Also include inherited namespaces from ancestor elements
-        for (var ancestor = element.Parent; ancestor != null; ancestor = ancestor.Parent)
-        {
-            foreach (var nsAttr in ancestor.Attributes().Where(a => a.IsNamespaceDeclaration))
-            {
-                var prefix = nsAttr.Name.LocalName == "xmlns" ? "" : nsAttr.Name.LocalName;
-                inScopeNamespaces.TryAdd(prefix, nsAttr.Value);
-            }
-        }
+        var inScopeNamespaces = InScopeNamespacesOf(element);
 
         return new XsltElement
         {
@@ -300,20 +286,7 @@ public sealed partial class StylesheetParser
         ValidateSelectContentExclusive(selectAttr, element, "XTSE0840", "xsl:attribute", location);
 
         // Collect in-scope namespaces for prefix resolution (XTDE0860)
-        var inScopeNamespaces = new Dictionary<string, string>();
-        foreach (var nsAttr in element.Attributes().Where(a => a.IsNamespaceDeclaration))
-        {
-            var prefix = nsAttr.Name.LocalName == "xmlns" ? "" : nsAttr.Name.LocalName;
-            inScopeNamespaces[prefix] = nsAttr.Value;
-        }
-        for (var ancestor = element.Parent; ancestor != null; ancestor = ancestor.Parent)
-        {
-            foreach (var nsAttr in ancestor.Attributes().Where(a => a.IsNamespaceDeclaration))
-            {
-                var prefix = nsAttr.Name.LocalName == "xmlns" ? "" : nsAttr.Name.LocalName;
-                inScopeNamespaces.TryAdd(prefix, nsAttr.Value);
-            }
-        }
+        var inScopeNamespaces = InScopeNamespacesOf(element);
 
         return new XsltAttribute
         {
@@ -385,7 +358,7 @@ public sealed partial class StylesheetParser
 
     private XsltNamespace ParseNamespaceInstr(XElement element, SourceLocation? location)
     {
-        var name = ParseAvt(element.Attribute("name")!.Value, element, element.Attribute("name"));
+        var name = ParseAvt(RequiredAttribute(element, "name").Value, element, element.Attribute("name"));
         var selectAttr = element.Attribute("select");
 
         // XTSE0910: select and non-empty content are mutually exclusive
@@ -428,4 +401,22 @@ public sealed partial class StylesheetParser
         return new XsltLiteralText { Value = value };
     }
 
+    /// <summary>
+    /// Every namespace binding in scope on <paramref name="element"/>, nearest declaration
+    /// winning ("" is the default namespace). For prefixes that are only known at run time,
+    /// such as a QName produced by an AVT.
+    /// </summary>
+    private static Dictionary<string, string> InScopeNamespacesOf(XElement element)
+    {
+        var inScope = new Dictionary<string, string>();
+        for (var e = element; e != null; e = e.Parent)
+        {
+            foreach (var nsAttr in e.Attributes().Where(a => a.IsNamespaceDeclaration))
+            {
+                var prefix = nsAttr.Name.LocalName == "xmlns" ? "" : nsAttr.Name.LocalName;
+                inScope.TryAdd(prefix, nsAttr.Value);
+            }
+        }
+        return inScope;
+    }
 }

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.ControlFlow.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.ControlFlow.cs
@@ -109,7 +109,7 @@ public sealed partial class StylesheetParser
 
     private XsltForEach ParseForEach(XElement element, SourceLocation? location)
     {
-        var select = ParseExpr(element.Attribute("select")!.Value, element.Attribute("select"));
+        var select = ParseExpr(RequiredAttribute(element, "select").Value, element.Attribute("select"));
 
         var sorts = new List<XsltSort>();
         var bodyInstructions = new List<XsltInstruction>();
@@ -171,7 +171,7 @@ public sealed partial class StylesheetParser
 
     private XsltForEachGroup ParseForEachGroup(XElement element, SourceLocation? location)
     {
-        var select = ParseExpr(element.Attribute("select")!.Value, element.Attribute("select"));
+        var select = ParseExpr(RequiredAttribute(element, "select").Value, element.Attribute("select"));
         var groupByAttr = element.Attribute("group-by");
         var groupAdjacentAttr = element.Attribute("group-adjacent");
         var groupStartingWithAttr = element.Attribute("group-starting-with");
@@ -257,7 +257,7 @@ public sealed partial class StylesheetParser
 
     private XsltIterate ParseIterate(XElement element, SourceLocation? location)
     {
-        var select = ParseExpr(element.Attribute("select")!.Value, element.Attribute("select"));
+        var select = ParseExpr(RequiredAttribute(element, "select").Value, element.Attribute("select"));
 
         var parameters = new List<XsltParam>();
         XsltSequenceConstructor? onCompletion = null;

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
@@ -2403,7 +2403,7 @@ public sealed partial class StylesheetParser
 
     private static XsltCharacterMap ParseCharacterMap(XElement element)
     {
-        var name = ParseQName(element.Attribute("name")!.Value, element);
+        var name = ParseQName(RequiredAttribute(element, "name").Value, element);
         var useAttr = element.Attribute("use-character-maps");
 
         var useCharacterMaps = new List<QName>();
@@ -2521,7 +2521,7 @@ public sealed partial class StylesheetParser
 
     private XsltAccumulator ParseAccumulator(XElement element)
     {
-        var name = ParseQName(element.Attribute("name")!.Value, element);
+        var name = ParseQName(RequiredAttribute(element, "name").Value, element);
         var asAttr = element.Attribute("as");
         var initialValueAttr = element.Attribute("initial-value");
         var streamableAttr = element.Attribute("streamable");
@@ -2529,7 +2529,7 @@ public sealed partial class StylesheetParser
         var rules = new List<XsltAccumulatorRule>();
         foreach (var child in element.Elements(XsltNs + "accumulator-rule"))
         {
-            var matchStr = child.Attribute("match")!.Value;
+            var matchStr = RequiredAttribute(child, "match").Value;
 
             // XPST0008: $value is not in scope in accumulator match patterns (only in select)
             if (System.Text.RegularExpressions.Regex.IsMatch(matchStr, @"\$value\b"))
@@ -2571,9 +2571,9 @@ public sealed partial class StylesheetParser
         return new XsltAccumulator
         {
             Name = name,
-            SourceName = element.Attribute("name")!.Value,
+            SourceName = RequiredAttribute(element, "name").Value,
             As = asAttr != null ? ParseSequenceType(asAttr.Value, element) : null,
-            InitialValue = ParseExpr(initialValueAttr!.Value),
+            InitialValue = ParseExpr(RequiredAttribute(element, "initial-value").Value),
             Rules = rules,
             Streamable = isStreamable
         };

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Functions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Functions.cs
@@ -66,8 +66,8 @@ public sealed partial class StylesheetParser
 
     private XsltAnalyzeString ParseAnalyzeString(XElement element, SourceLocation? location)
     {
-        var select = ParseExpr(element.Attribute("select")!.Value, element.Attribute("select"));
-        var regex = ParseAvt(element.Attribute("regex")!.Value, element, element.Attribute("regex"));
+        var select = ParseExpr(RequiredAttribute(element, "select").Value, element.Attribute("select"));
+        var regex = ParseAvt(RequiredAttribute(element, "regex").Value, element, element.Attribute("regex"));
         var flagsAttr = element.Attribute("flags");
 
         XsltSequenceConstructor? matchingSubstring = null;
@@ -909,7 +909,7 @@ public sealed partial class StylesheetParser
                 System.Xml.XmlConvert.VerifyNCName(parts[0]);
                 System.Xml.XmlConvert.VerifyNCName(parts[1]);
             }
-            catch (System.Xml.XmlException)
+            catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
             {
                 throw new XsltException($"XTDE1400: The argument to function-available() ('{name}') is not a valid QName");
             }
@@ -927,7 +927,7 @@ public sealed partial class StylesheetParser
             {
                 System.Xml.XmlConvert.VerifyNCName(name);
             }
-            catch (System.Xml.XmlException)
+            catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
             {
                 throw new XsltException($"XTDE1400: The argument to function-available() ('{name}') is not a valid QName");
             }

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.NodeIO.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.NodeIO.cs
@@ -454,7 +454,7 @@ public sealed partial class StylesheetParser
 
     private XsltProcessingInstruction ParsePI(XElement element, SourceLocation? location)
     {
-        var name = ParseAvt(element.Attribute("name")!.Value, element, element.Attribute("name"));
+        var name = ParseAvt(RequiredAttribute(element, "name").Value, element, element.Attribute("name"));
         var selectAttr = element.Attribute("select");
 
         // XTSE0880: select and non-empty content are mutually exclusive

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Variables.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Variables.cs
@@ -112,7 +112,7 @@ public sealed partial class StylesheetParser
 
     private XsltParam ParseParam(XElement element, bool isGlobal = false, bool allowTunnel = true)
     {
-        var name = ParseQName(element.Attribute("name")!.Value, element);
+        var name = ParseQName(RequiredAttribute(element, "name").Value, element);
         var asAttr = element.Attribute("as");
         var selectAttr = element.Attribute("select");
         var requiredAttr = element.Attribute("required");
@@ -214,7 +214,7 @@ public sealed partial class StylesheetParser
 
     private XsltParamInstruction ParseParamInstr(XElement element, SourceLocation? location)
     {
-        var name = ParseQName(element.Attribute("name")!.Value, element);
+        var name = ParseQName(RequiredAttribute(element, "name").Value, element);
         var asAttr = element.Attribute("as");
         var selectAttr = element.Attribute("select");
         var requiredAttr = element.Attribute("required");
@@ -235,7 +235,7 @@ public sealed partial class StylesheetParser
 
     private XsltWithParam ParseWithParam(XElement element)
     {
-        var name = ParseQName(element.Attribute("name")!.Value, element);
+        var name = ParseQName(RequiredAttribute(element, "name").Value, element);
         var asAttr = element.Attribute("as");
         var selectAttr = element.Attribute("select");
         var tunnelAttr = element.Attribute("tunnel");

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
@@ -1539,14 +1539,16 @@ public sealed partial class StylesheetParser
             Content = selectAttr == null && element.Nodes().Any() ? ParseSequenceConstructor(element) : null,
             Terminate = terminateAttr?.Value is "yes" or "true" or "1",
             TerminateAvt = isTerminateAvt ? ParseAvt(terminateAttr!.Value, element, terminateAttr) : null,
-            ErrorCode = errorCodeAttr?.Value
+            ErrorCode = errorCodeAttr?.Value,
+            ErrorCodeAvt = errorCodeAttr != null ? ParseAvt(errorCodeAttr.Value, element, errorCodeAttr) : null,
+            ErrorCodeNamespaces = errorCodeAttr != null ? InScopeNamespacesOf(element) : null,
         };
     }
 
 
     private XsltAssert ParseAssert(XElement element, SourceLocation? location)
     {
-        var test = ParseExpr(element.Attribute("test")!.Value, element.Attribute("test"));
+        var test = ParseExpr(RequiredAttribute(element, "test").Value, element.Attribute("test"));
         var selectAttr = element.Attribute("select");
         var errorCodeAttr = element.Attribute("error-code");
 
@@ -1603,7 +1605,7 @@ public sealed partial class StylesheetParser
 
     private XsltMapEntry ParseMapEntry(XElement element, SourceLocation? location)
     {
-        var key = ParseExpr(element.Attribute("key")!.Value, element.Attribute("key"));
+        var key = ParseExpr(RequiredAttribute(element, "key").Value, element.Attribute("key"));
         var selectAttr = element.Attribute("select");
 
         // XTSE3280: xsl:map-entry with select must not have content other than xsl:fallback
@@ -2914,6 +2916,17 @@ public sealed partial class StylesheetParser
         };
     }
 
+
+    /// <summary>
+    /// The attribute <paramref name="element"/> must carry, or the static error XTSE0010. The
+    /// parser used to dereference required attributes with <c>Attribute("x")!.Value</c>, which
+    /// asserts exactly the condition the stylesheet is being checked FOR: a missing attribute
+    /// became a NullReferenceException instead of a diagnosis (BUGS.md #32).
+    /// </summary>
+    private static XAttribute RequiredAttribute(XElement element, string name)
+        => element.Attribute(name) ?? throw new XsltException(
+            $"XTSE0010: xsl:{element.Name.LocalName} requires the '{name}' attribute",
+            GetSourceLocation(element));
 
     private static SourceLocation? GetSourceLocation(XElement element)
     {

--- a/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorAfterFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorAfterFunction.cs
@@ -42,6 +42,7 @@ internal sealed class XsltAccumulatorAfterFunction : PhoenixmlDb.XQuery.Ast.XQue
         // the XSLT context is the template match node, not the path step's current node.
         var node = XQueryFocus.ItemOrNull(context) ?? _context.ContextItem
             ?? throw new XsltException("XTDE3340: accumulator-after() called with no context item");
+        node = XsltFunctionValidation.RequireAccumulatorContextNode(node, "accumulator-after");
 
         // Check if the accumulator is applicable in the current mode. When it is not, the
         // error code depends on the tree: for the principal source document, the initial

--- a/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
@@ -42,6 +42,7 @@ internal sealed class XsltAccumulatorBeforeFunction : PhoenixmlDb.XQuery.Ast.XQu
         // the XSLT context is the template match node, not the path step's current node.
         var node = XQueryFocus.ItemOrNull(context) ?? _context.ContextItem
             ?? throw new XsltException("XTDE3340: accumulator-before() called with no context item");
+        node = XsltFunctionValidation.RequireAccumulatorContextNode(node, "accumulator-before");
 
         // Check if the accumulator is applicable in the current mode. When it is not, the
         // error code depends on the tree: for the principal source document, the initial

--- a/src/PhoenixmlDb.Xslt/Engine/XsltFunctionValidation.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltFunctionValidation.cs
@@ -26,6 +26,29 @@ namespace PhoenixmlDb.Xslt.Engine;
 /// </summary>
 internal static class XsltFunctionValidation
 {
+    /// <summary>
+    /// accumulator-before / accumulator-after apply to a node that is not an attribute or
+    /// namespace node; anything else is the type error XTTE3360. Without this check a non-node
+    /// context item fell through to the accumulator lookup and surfaced as XTDE3340 "no
+    /// accumulator is available" — a claim about the stylesheet, for a mistake in the call.
+    /// </summary>
+    internal static object RequireAccumulatorContextNode(object item, string functionName)
+    {
+        if (item is PhoenixmlDb.Xdm.Nodes.XdmNode and not (PhoenixmlDb.Xdm.Nodes.XdmAttribute or PhoenixmlDb.Xdm.Nodes.XdmNamespace))
+            return item;
+        // The XSLT context reports an absent focus as a sentinel object, not null (BUGS.md #17).
+        // No context item at all is XPDY0002, not a type error about the item.
+        if (ReferenceEquals(item, PhoenixmlDb.XQuery.Execution.QueryExecutionContext.AbsentFocus))
+            throw new XsltException($"XPDY0002: {functionName}() requires a context item, but the focus is absent");
+        var what = item switch
+        {
+            PhoenixmlDb.Xdm.Nodes.XdmAttribute => "an attribute node",
+            PhoenixmlDb.Xdm.Nodes.XdmNamespace => "a namespace node",
+            _ => "not a node",
+        };
+        throw new XsltException($"XTTE3360: {functionName}() requires the context item to be a node other than an attribute or namespace node, but it is {what}");
+    }
+
     internal static void ValidateQNameArgument(string name, string errorCode, string functionName)
     {
         if (string.IsNullOrEmpty(name))
@@ -48,7 +71,7 @@ internal static class XsltFunctionValidation
                 System.Xml.XmlConvert.VerifyNCName(name);
             }
         }
-        catch (System.Xml.XmlException)
+        catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
         {
             throw new XsltException($"{errorCode}: The argument to {functionName}() ('{name}') is not a valid EQName");
         }

--- a/src/PhoenixmlDb.Xslt/Engine/XsltKeyFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltKeyFunction.cs
@@ -58,7 +58,7 @@ internal sealed class XsltKeyFunction : PhoenixmlDb.XQuery.Ast.XQueryFunction
                 System.Xml.XmlConvert.VerifyNCName(keyName);
             }
         }
-        catch (System.Xml.XmlException)
+        catch (Exception ex) when (ex is System.Xml.XmlException or ArgumentException) // "" throws ArgumentException
         {
             throw new XsltException($"XTDE1260: The first argument of the key() function ('{keyName}') is not a valid QName");
         }


### PR DESCRIPTION
Batch 3 against #13. **+18 W3C cases, 0 lost.** Same-checkout A/B, full sweep:
**10,137 → 10,156 / 10,630**. The measured +19 includes the flaky `call-template-1002`; the other 18
match the fixed sites case for case.

| site | was | now | gain |
|---|---|---|---|
| `xsl:message/@error-code` | parsed, never read, so always XTMM9000 | honoured: AVT → EQName/QName; xqt-errors codes reported bare; invalid → XTMM9000 (message-0406) | 9 |
| `accumulator-before` / `-after` on a non-node | XTDE3340 "no accumulator available" | XTTE3360 (absent focus → XPDY0002); one shared check for both twins | 3 |
| 16 required-attribute `!.Value` dereferences, plus `initial-value` (BUGS.md #32) | NullReferenceException | `RequiredAttribute()` → XTSE0010 | 3 |
| 9 `VerifyNCName` try blocks that caught only `XmlException` | an empty name part (`err:`, `:prop`) escaped as `ArgumentException` | caught; each block reviewed to contain only name checks | 3 |

The two dereferences guarded by a ternary are left alone, because they're on optional attributes
(`xsl:output/@name`, `xsl:decimal-format/@name`).

The in-scope-namespace walk, which was inlined twice, is now `InScopeNamespacesOf()` and is shared
with `xsl:message`.

XSLT unit suite: 1483/1484 (1 skipped), 0 failed.

Refs #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn
