### PR TITLE
fix: a function's result reaches its caller whole and once (function-1022)

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
@@ -172,7 +172,7 @@ internal sealed partial class DefaultXsltExecutionContext
         if (_collectTextAsSequenceItems && _serializingElementDepth == 0
             && _sequenceAccumulator != null)
         {
-            AppendToSeqAccumulator(new Xdm.TextNodeItem(value));
+            AccumulateTextItem(value);
         }
         else if ((disableOutputEscaping && _temporaryOutputDepth == 0) || _textContentDepth > 0)
         {
@@ -230,6 +230,41 @@ internal sealed partial class DefaultXsltExecutionContext
     }
 
 
+    /// <summary>
+    /// Adds a text node to the sequence being built and, at the top level of a function body,
+    /// also writes it to <c>_output</c>. Returns whether it wrote to <c>_output</c>.
+    /// </summary>
+    /// <remarks>
+    /// A function's result is assembled from BOTH channels: <c>_output</c> carries elements and
+    /// text in source order, and the assembly skips accumulated TextNodeItems as duplicates of
+    /// that text. So a text node that reaches only the accumulator is dropped. WriteTextItem
+    /// wrote both; WriteText's text-as-items branch — which xsl:copy-of of a text node reaches —
+    /// wrote only the accumulator. So a function returning <c>(text, element)</c> lost the text:
+    /// <c>f:id($d/r/node())</c> over <c>&lt;r&gt; inner &lt;b/&gt;&lt;/r&gt;</c> gave back only
+    /// the element, which is why W3C function-1022 found an index where the spec finds none.
+    /// One helper now, so the two cannot disagree again.
+    /// </remarks>
+    private bool AccumulateTextItem(string value)
+    {
+        AppendToSeqAccumulator(new Xdm.TextNodeItem(value));
+        // In function bodies at the top level (not inside value-of, attribute,
+        // comment/PI content), also write escaped text to _output so that
+        // text and LRE elements preserve their source order when the function
+        // result is assembled from both _sequenceAccumulator and _output.
+        if (_functionBodyDepth == 0 || _textContentDepth != 0)
+            return false;
+        EmitText(value);
+        // This item now OWNS the text just written. Without this the weave emits the
+        // item and then the same text again as a trailing output chunk.
+        if (_currentAsBodyCapture is { } cap
+            && ReferenceEquals(_sequenceAccumulator, cap.Accumulator)
+            && cap.ConsumedTo.Count > 0)
+        {
+            cap.ConsumedTo[^1] = _output.Length - cap.OutputBaseLen;
+        }
+        return true;
+    }
+
     public override void WriteTextItem(string value)
     {
         // If sequence accumulation is active, add as a TextNodeItem marker
@@ -237,24 +272,7 @@ internal sealed partial class DefaultXsltExecutionContext
         var emittedToOutput = false;
         if (_sequenceAccumulator != null)
         {
-            AppendToSeqAccumulator(new Xdm.TextNodeItem(value));
-            // In function bodies at the top level (not inside value-of, attribute,
-            // comment/PI content), also write escaped text to _output so that
-            // text and LRE elements preserve their source order when the function
-            // result is assembled from both _sequenceAccumulator and _output.
-            if (_functionBodyDepth > 0 && _textContentDepth == 0)
-            {
-                EmitText(value);
-                emittedToOutput = true;
-                // This item now OWNS the text just written. Without this the weave emits the
-                // item and then the same text again as a trailing output chunk.
-                if (_currentAsBodyCapture is { } cap
-                    && ReferenceEquals(_sequenceAccumulator, cap.Accumulator)
-                    && cap.ConsumedTo.Count > 0)
-                {
-                    cap.ConsumedTo[^1] = _output.Length - cap.OutputBaseLen;
-                }
-            }
+            emittedToOutput = AccumulateTextItem(value);
         }
         else
         {

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
@@ -201,6 +201,11 @@ internal sealed partial class DefaultXsltExecutionContext
         public bool CollectTextAsSequenceItems { get; init; }
         public bool LastResultWasAtomic { get; init; }
         public List<StringBuilder> CollectedAttributes { get; init; }
+        public TreeConstructor? ActiveTreeConstructor { get; init; }
+        public bool TcFragmentIncomplete { get; init; }
+        public bool SuppressTcIncomplete { get; init; }
+        public bool UntypedRtfFlipActive { get; init; }
+        public bool UntypedRtfFlipDivergent { get; init; }
     }
 
 

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -108,6 +108,11 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
             CollectTextAsSequenceItems = _collectTextAsSequenceItems,
             LastResultWasAtomic = _lastResultWasAtomic,
             CollectedAttributes = new List<StringBuilder>(_collectedAttributesStack),
+            ActiveTreeConstructor = _activeTreeConstructor,
+            TcFragmentIncomplete = _tcFragmentIncomplete,
+            SuppressTcIncomplete = _suppressTcIncomplete,
+            UntypedRtfFlipActive = _untypedRtfFlipActive,
+            UntypedRtfFlipDivergent = _untypedRtfFlipDivergent,
         };
 
         // Declare this body's base: content below it belongs to an enclosing scope and must
@@ -133,6 +138,21 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
         _lastResultWasAtomic = false;
         _collectedAttributesStack.Clear();
 
+        // The body's value is assembled from its OWN channels, so it must not build into an
+        // enclosing temp tree's constructor. Only the two xsl:variable seams installed a
+        // constructor of their own; the function and typed-param seams inherited the caller's,
+        // and xsl:copy-of inside a function body cloned straight into the tree the caller was
+        // building — before the function's result was copied in again, so
+        //   <xsl:variable name="v"><xsl:copy-of select="f:wrap($nodes)"/></xsl:variable>
+        // held two <a> elements where f:wrap returns one. It also left _untypedRtfFlipActive
+        // set inside a typed body, which that flag's contract rules out. A seam that wants a
+        // constructor installs its own after this.
+        _activeTreeConstructor = null;
+        _tcFragmentIncomplete = false;
+        _suppressTcIncomplete = false;
+        _untypedRtfFlipActive = false;
+        _untypedRtfFlipDivergent = false;
+
         return saved;
     }
 
@@ -150,6 +170,11 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
         _collectedAttributesStack.Clear();
         for (var i = saved.CollectedAttributes.Count - 1; i >= 0; i--)
             _collectedAttributesStack.Push(saved.CollectedAttributes[i]);
+        _activeTreeConstructor = saved.ActiveTreeConstructor;
+        _tcFragmentIncomplete = saved.TcFragmentIncomplete;
+        _suppressTcIncomplete = saved.SuppressTcIncomplete;
+        _untypedRtfFlipActive = saved.UntypedRtfFlipActive;
+        _untypedRtfFlipDivergent = saved.UntypedRtfFlipDivergent;
     }
 
 

--- a/tests/PhoenixmlDb.Xslt.Tests/FunctionResultContentTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/FunctionResultContentTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A stylesheet function's result must reach its caller whole and once. Two defects, both
+/// behind W3C xslt30-test function-1022, lost or doubled content on the way out.
+/// <list type="bullet">
+/// <item><b>Lost text.</b> A function result is assembled from two channels: <c>_output</c>
+/// holds elements and text in source order, and accumulated TextNodeItems are skipped as
+/// duplicates of that text. xsl:copy-of of a text node wrote ONLY the accumulator, so
+/// <c>f:id($r/node())</c> over <c>&lt;r&gt; inner &lt;b/&gt;&lt;/r&gt;</c> returned just the
+/// element.</item>
+/// <item><b>Doubled content.</b> A function body ran with the caller's temp-tree constructor
+/// still active, so xsl:copy-of inside it cloned into the variable being built, and then the
+/// function's result was copied in as well.</item>
+/// </list>
+/// function-1022 expects XPTY0004 from <c>subsequence()</c> given an empty position; with the
+/// text node gone the position it computes was found and the error never raised.
+/// </summary>
+public sealed class FunctionResultContentTests
+{
+    private static async Task<string> RunAsync(string body)
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:f="urn:f" exclude-result-prefixes="f">
+              <xsl:output method="xml" indent="no" omit-xml-declaration="yes"/>
+              <xsl:function name="f:id"><xsl:param name="s"/><xsl:copy-of select="$s"/></xsl:function>
+              <xsl:function name="f:wrap"><xsl:param name="s"/><a><xsl:copy-of select="$s"/></a></xsl:function>
+              <xsl:function name="f:wrap-id"><xsl:param name="s"/><a><xsl:copy-of select="f:id($s)"/></a></xsl:function>
+              <xsl:template match="/">
+                <xsl:variable name="d"><r> inner <b>x</b></r></xsl:variable>
+                {{body}}
+              </xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("""<out><xsl:copy-of select="f:id($d/r/node())"/></out>""", "<out> inner <b>x</b></out>")]
+    [InlineData("""<out><a><xsl:copy-of select="f:id($d/r/node())"/></a></out>""", "<out><a> inner <b>x</b></a></out>")]
+    [InlineData("""<out><xsl:copy-of select="f:wrap-id($d/r/node())"/></out>""", "<out><a> inner <b>x</b></a></out>")]
+    public async Task ACopiedTextNode_SurvivesTheFunctionBoundary(string body, string expected)
+        => (await RunAsync(body)).Should().Be(expected);
+
+    [Fact]
+    public async Task AFunctionReturningTextThenElement_ReturnsBothItems()
+        => (await RunAsync("""<out><xsl:value-of select="let $r := f:id($d/r/node()) return (count($r), $r[1] instance of text())"/></out>"""))
+            .Should().Be("<out>2 true</out>");
+
+    [Theory]
+    [InlineData("f:id($d/r/node())", " inner x", "<v> inner <b>x</b></v>")]
+    [InlineData("f:wrap($d/r/node())", " inner x", "<v><a> inner <b>x</b></a></v>")]
+    [InlineData("f:wrap-id($d/r/node())", " inner x", "<v><a> inner <b>x</b></a></v>")]
+    public async Task AFunctionResultCopiedIntoAVariable_AppearsOnce(string call, string stringValue, string tree)
+    {
+        // Previously f:wrap($d/r/node()) gave "<v><a> inner <b>x</b></a><a> inner <b>x</b></a></v>".
+        var body = $"""
+            <xsl:variable name="v"><xsl:copy-of select="{call}"/></xsl:variable>
+            <out><xsl:value-of select="string($v)"/>|<v><xsl:copy-of select="$v"/></v></out>
+            """;
+        (await RunAsync(body)).Should().Be($"<out>{stringValue}|{tree}</out>");
+    }
+}


### PR DESCRIPTION
Two defects between an `xsl:function` body and the tree its caller builds. Together they are behind W3C xslt30-test **function-1022**.

### Lost text
A function result is assembled from two channels. `_output` holds elements and text in source order, and accumulated `TextNodeItem`s are skipped as duplicates of that text. `WriteTextItem` wrote to both channels. `WriteText`'s text-as-items branch, which `xsl:copy-of` of a text node reaches, wrote only to the accumulator, so the text never made it into the result:

```xml
<xsl:function name="f:id"><xsl:param name="s"/><xsl:copy-of select="$s"/></xsl:function>
<out><xsl:copy-of select="f:id($d/r/node())"/></out>   <!-- $d/r = <r> inner <b>x</b></r> -->
```
Before: `<out><b>x</b></out>`. After: `<out> inner <b>x</b></out>`. Both paths now go through one helper, `AccumulateTextItem`, so they can't disagree again.

### Doubled content
A function body ran with the caller's temp-tree constructor still active. `xsl:copy-of` inside the body cloned into the variable being built, and then the function's result was copied in as well:

```xml
<xsl:variable name="v"><xsl:copy-of select="f:wrap($d/r/node())"/></xsl:variable>
```
Before: `$v` held two `<a>` elements. After: one. `EnterTypedBody` now suspends the constructor and its flip flags for every typed body, and `ExitTypedBody` restores them. Seams that want a constructor (the two `xsl:variable` seams) still install their own after entry. This also stops `_untypedRtfFlipActive` staying set inside a typed body, which that flag's own contract already rules out.

### Evidence
- function-1022 expects XPTY0004 from `subsequence()` given an empty position. With the text lost, the position was found and no error was raised. It now raises XPTY0004.
- Full XSLT sweep on the same checkout: **10,157 → 10,158**, with zero per-set losses. The one gain is `decl/function` going from 96 to 97.
- 7 new tests in `FunctionResultContentTests`, all of which **fail on the old code**. The XSLT unit suite passes on net10.0: 1,490 passed, 0 failed. net8.0 couldn't build locally because of a missing-apphost environment issue, so CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn