### PR TITLE
fix: new-each-time="no" memoizes, and the memo key is an identity

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
@@ -2042,19 +2042,14 @@ internal sealed partial class DefaultXsltExecutionContext
         if (_options?.TraceListener != null)
             _options.TraceListener(_templateDepth, "call-function", $"{func.Name.LocalName}#{arguments.Count}");
 
-        // cache="yes" memoization: check cache before executing function body
-        string? cacheKey = null;
-        if (func.Cache)
+        // Memoization: cache="yes" asks for it, and new-each-time="no" declares the function
+        // deterministic — two calls with identical arguments must return IDENTICAL results, so
+        // a node it constructs is the same node each time (XSLT 3.0 §10.3.2). Without this,
+        // `f(1) | f(1)` held two nodes where the spec requires one (W3C function-1025/1026).
+        FunctionMemoKey? cacheKey = null;
+        if (func.Cache || func.NewEachTime == "no")
         {
-            var keyBuilder = new System.Text.StringBuilder();
-            keyBuilder.Append(func.Name.Namespace.Value).Append(':').Append(func.Name.LocalName).Append('(');
-            for (var ai = 0; ai < arguments.Count; ai++)
-            {
-                if (ai > 0) keyBuilder.Append(',');
-                AppendCacheKey(keyBuilder, arguments[ai]);
-            }
-            keyBuilder.Append(')');
-            cacheKey = keyBuilder.ToString();
+            cacheKey = new FunctionMemoKey(func, arguments);
             if (_functionCache.TryGetValue(cacheKey, out var cachedResult))
                 return cachedResult;
         }

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
@@ -477,9 +477,8 @@ internal sealed partial class DefaultXsltExecutionContext
     internal readonly Stack<XsltTemplate> _currentTemplateStack = new();
 
 
-    // Per XSLT 3.0 §10.3: cache="yes" memoization for stylesheet functions
-    // Key: (function QName key string, serialized argument list)
-    private readonly Dictionary<string, object?> _functionCache = new(StringComparer.Ordinal);
+    // Memoized stylesheet function results — cache="yes" and new-each-time="no" (XSLT 3.0 §10.3).
+    private readonly Dictionary<FunctionMemoKey, object?> _functionCache = new();
 
 
     // Cooperative cancellation and output size guard

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -484,61 +484,6 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
 
 
     /// <summary>
-    /// Appends a type-aware cache key representation for a function argument.
-    /// Different types need different key strategies to preserve identity/equality semantics.
-    /// </summary>
-    private static void AppendCacheKey(System.Text.StringBuilder sb, object? arg)
-    {
-        switch (arg)
-        {
-            case null:
-                sb.Append("()");
-                break;
-            case QName qn:
-                // Use resolved namespace URI — QNames from node-name() have RuntimeNamespace,
-                // not ExpandedNamespace, so ToString() only shows prefix:local
-                sb.Append("Q{").Append(qn.ResolvedNamespace ?? "").Append('}').Append(qn.LocalName);
-                break;
-            case XdmNode node:
-                // Node identity: use runtime hash code (reference identity)
-                sb.Append("node@").Append(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(node));
-                break;
-            case IDictionary<object, object?> map:
-                // Map deep content: serialize entries deterministically
-                sb.Append("map{");
-                var first = true;
-                foreach (var kvp in map.OrderBy(k => k.Key?.ToString() ?? "", StringComparer.Ordinal))
-                {
-                    if (!first) sb.Append(',');
-                    first = false;
-                    AppendCacheKey(sb, kvp.Key);
-                    sb.Append(':');
-                    AppendCacheKey(sb, kvp.Value);
-                }
-                sb.Append('}');
-                break;
-            case List<object?> array:
-                // Array deep content
-                sb.Append('[');
-                for (var i = 0; i < array.Count; i++)
-                {
-                    if (i > 0) sb.Append(',');
-                    AppendCacheKey(sb, array[i]);
-                }
-                sb.Append(']');
-                break;
-            case PhoenixmlDb.XQuery.Ast.XQueryFunction func:
-                // Function identity: use runtime hash code
-                sb.Append("fn@").Append(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(func));
-                break;
-            default:
-                sb.Append(arg.ToString());
-                break;
-        }
-    }
-
-
-    /// <summary>
     /// Checks cancellation token and output size limit. Called at loop boundaries
     /// (apply-templates per-node, for-each per-item, iterate per-item) and template entry
     /// to ensure runaway transformations are terminated promptly.

--- a/src/PhoenixmlDb.Xslt/Engine/FunctionMemoKey.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/FunctionMemoKey.cs
@@ -1,0 +1,123 @@
+using PhoenixmlDb.Core;
+using PhoenixmlDb.Xdm.Nodes;
+using PhoenixmlDb.Xslt.Ast;
+
+namespace PhoenixmlDb.Xslt.Engine;
+
+/// <summary>
+/// Identifies one call of a memoized stylesheet function: the function and its arguments,
+/// compared by the XSLT 3.0 §10.3.2 notion of identical — nodes and function items by
+/// identity, atomic values by type and value, maps and arrays by content.
+/// </summary>
+/// <remarks>
+/// This replaces a string key built by concatenating each argument's text form, which was not
+/// an identity at all. A multi-item sequence rendered as its CLR type name, so
+/// <c>f((1, 2))</c> and <c>f((3, 4))</c> shared one entry; <c>f('1')</c> and <c>f(1)</c>
+/// rendered alike; a comma inside a string collided across argument boundaries; and nodes were
+/// told apart by hash code, which distinct nodes can share. Each returned another call's result.
+/// </remarks>
+internal sealed class FunctionMemoKey : IEquatable<FunctionMemoKey>
+{
+    private readonly XsltFunction _function;
+    private readonly object?[] _arguments;
+    private readonly int _hash;
+
+    public FunctionMemoKey(XsltFunction function, IReadOnlyList<object?> arguments)
+    {
+        _function = function;
+        _arguments = arguments.ToArray();
+        var hash = new HashCode();
+        hash.Add(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(function));
+        foreach (var argument in _arguments)
+            hash.Add(ValueHash(argument));
+        _hash = hash.ToHashCode();
+    }
+
+    public bool Equals(FunctionMemoKey? other)
+    {
+        if (other is null || _hash != other._hash || !ReferenceEquals(_function, other._function)
+            || _arguments.Length != other._arguments.Length)
+            return false;
+        for (var i = 0; i < _arguments.Length; i++)
+            if (!ValueEquals(_arguments[i], other._arguments[i]))
+                return false;
+        return true;
+    }
+
+    public override bool Equals(object? obj) => obj is FunctionMemoKey other && Equals(other);
+
+    public override int GetHashCode() => _hash;
+
+    /// <summary>A value is a sequence: null is empty, object?[] is its items, anything else one item.</summary>
+    private static bool ValueEquals(object? a, object? b)
+    {
+        var aItems = a as object?[];
+        var bItems = b as object?[];
+        if (aItems is null && bItems is null)
+            return ItemEquals(a, b);
+        var aLength = aItems?.Length ?? (a is null ? 0 : 1);
+        var bLength = bItems?.Length ?? (b is null ? 0 : 1);
+        if (aLength != bLength)
+            return false;
+        for (var i = 0; i < aLength; i++)
+            if (!ItemEquals(aItems is null ? a : aItems[i], bItems is null ? b : bItems[i]))
+                return false;
+        return true;
+    }
+
+    private static bool ItemEquals(object? a, object? b)
+    {
+        if (ReferenceEquals(a, b))
+            return true;
+        if (a is null || b is null)
+            return false;
+        switch (a)
+        {
+            case XdmNode:
+            case PhoenixmlDb.XQuery.Ast.XQueryFunction:
+                return false;
+            case QName qa:
+                return b is QName qb
+                    && string.Equals(qa.ResolvedNamespace ?? "", qb.ResolvedNamespace ?? "", StringComparison.Ordinal)
+                    && string.Equals(qa.LocalName, qb.LocalName, StringComparison.Ordinal);
+            case IDictionary<object, object?> map:
+                if (b is not IDictionary<object, object?> otherMap || map.Count != otherMap.Count)
+                    return false;
+                foreach (var entry in map)
+                    if (!otherMap.TryGetValue(entry.Key, out var otherValue) || !ValueEquals(entry.Value, otherValue))
+                        return false;
+                return true;
+            case List<object?> array:
+                if (b is not List<object?> otherArray || array.Count != otherArray.Count)
+                    return false;
+                for (var i = 0; i < array.Count; i++)
+                    if (!ValueEquals(array[i], otherArray[i]))
+                        return false;
+                return true;
+            default:
+                return a.GetType() == b.GetType() && a.Equals(b);
+        }
+    }
+
+    private static int ValueHash(object? value)
+    {
+        if (value is not object?[] items)
+            return ItemHash(value);
+        var hash = new HashCode();
+        hash.Add(items.Length);
+        foreach (var item in items)
+            hash.Add(ItemHash(item));
+        return hash.ToHashCode();
+    }
+
+    private static int ItemHash(object? item) => item switch
+    {
+        null => 0,
+        XdmNode or PhoenixmlDb.XQuery.Ast.XQueryFunction => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(item),
+        QName q => HashCode.Combine(q.ResolvedNamespace ?? "", q.LocalName),
+        // Content equality, so the hash may only use what equal maps and arrays share.
+        IDictionary<object, object?> map => HashCode.Combine(1, map.Count),
+        List<object?> array => HashCode.Combine(2, array.Count),
+        _ => HashCode.Combine(item.GetType(), item),
+    };
+}

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
@@ -2064,12 +2064,20 @@ public sealed partial class StylesheetParser
                 throw new XsltException("XTSE0020: The 'override' and 'override-extension-function' attributes have conflicting values on xsl:function", location);
         }
 
+        // xsl:yes-or-no-or-maybe: true/1 and false/0 are synonyms of yes and no. Normalized, so
+        // the engine's memoization test sees new-each-time="false" as the "no" it is.
         var newEachTimeAttr = element.Attribute("new-each-time");
+        string? newEachTime = null;
         if (newEachTimeAttr != null)
         {
-            var val = newEachTimeAttr.Value.Trim();
-            if (val != "yes" && val != "no" && val != "maybe")
-                throw new XsltException($"XTSE0020: Invalid value '{newEachTimeAttr.Value}' for new-each-time attribute: must be 'yes', 'no', or 'maybe'", location);
+            newEachTime = newEachTimeAttr.Value.Trim() == "maybe"
+                ? "maybe"
+                : ParseYesNo(newEachTimeAttr) switch
+                {
+                    true => "yes",
+                    false => "no",
+                    null => throw new XsltException($"XTSE0020: Invalid value '{newEachTimeAttr.Value}' for new-each-time attribute: must be 'yes', 'no', or 'maybe'", location),
+                };
         }
 
         var cacheAttr = element.Attribute("cache");
@@ -2184,7 +2192,7 @@ public sealed partial class StylesheetParser
             Visibility = ParseVisibility(element.Attribute("visibility")?.Value),
             VisibilityAttr = element.Attribute("visibility")?.Value,
             Cache = ParseYesNo(cacheAttr) ?? false,
-            NewEachTime = newEachTimeAttr?.Value?.Trim(),
+            NewEachTime = newEachTime,
             Streamability = streamabilityValue,
             BaseUri = ResolveEffectiveBaseUri(element)
         };

--- a/tests/PhoenixmlDb.Xslt.Tests/FunctionMemoizationTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/FunctionMemoizationTests.cs
@@ -15,7 +15,8 @@ public sealed class FunctionMemoizationTests
     {
         var ss = $$"""
             <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-              xmlns:f="urn:f" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              xmlns:f="urn:f" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              xmlns:map="http://www.w3.org/2005/xpath-functions/map" exclude-result-prefixes="#all">
               <xsl:output method="text"/>
               {{function}}
               <xsl:template match="/">{{body}}</xsl:template>
@@ -84,6 +85,33 @@ public sealed class FunctionMemoizationTests
             """;
         (await RunAsync(functions, $"""<xsl:value-of select="{first}, '#', {second}" separator=""/>"""))
             .Should().Be($"{firstResult}#{secondResult}");
+    }
+
+    [Fact]
+    public async Task CacheYes_TellsMapKeysOfDifferentTypesApart()
+    {
+        // The old key rendered map keys by ToString, so map{1: 'x'} and map{'1': 'x'} — distinct
+        // maps, one keyed by an integer and one by a string — shared an entry.
+        var result = await RunAsync(
+            """<xsl:function name="f:key-type" cache="yes"><xsl:param name="m"/><xsl:sequence select="if (map:keys($m) instance of xs:integer) then 'integer' else 'string'"/></xsl:function>""",
+            """<xsl:value-of select="f:key-type(map{1: 'x'}), f:key-type(map{'1': 'x'})"/>""");
+        result.Should().Be("integer string");
+    }
+
+    [Fact]
+    public async Task CacheYes_TellsDistinctNodesWithEqualContentApart()
+    {
+        // A guard rather than a positive control: the old key compared nodes by hash code, and a
+        // collision between two live nodes cannot be forced, so this passed there too. Nodes are
+        // compared by identity now, which makes it hold by construction rather than by luck.
+        var result = await RunAsync(
+            """<xsl:function name="f:ident" cache="yes"><xsl:param name="n"/><xsl:sequence select="generate-id($n)"/></xsl:function>""",
+            """
+            <xsl:variable name="a"><x/></xsl:variable>
+            <xsl:variable name="b"><x/></xsl:variable>
+            <xsl:value-of select="f:ident($a/x) ne f:ident($b/x), f:ident($a/x) eq f:ident($a/x)"/>
+            """);
+        result.Should().Be("true true");
     }
 
     [Fact]

--- a/tests/PhoenixmlDb.Xslt.Tests/FunctionMemoizationTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/FunctionMemoizationTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Memoized stylesheet functions: <c>new-each-time="no"</c> declares a function deterministic,
+/// so identical calls return identical nodes (XSLT 3.0 §10.3.2, W3C function-1025/1026), and
+/// <c>cache="yes"</c> must never hand one call another call's result.
+/// </summary>
+public sealed class FunctionMemoizationTests
+{
+    private static async Task<string> RunAsync(string function, string body)
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:f="urn:f" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              {{function}}
+              <xsl:template match="/">{{body}}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    private const string MakeNode = """<xsl:param name="n"/><e><xsl:value-of select="$n"/></e>""";
+
+    [Theory]
+    [InlineData("no", "7")]
+    [InlineData("false", "7")]
+    [InlineData("0", "7")]
+    [InlineData("yes", "10")]
+    [InlineData("true", "10")]
+    public async Task NewEachTime_DecidesWhetherIdenticalCallsShareANode(string newEachTime, string expected)
+        => (await RunAsync(
+                $"""<xsl:function name="f:make" as="element()" new-each-time="{newEachTime}">{MakeNode}</xsl:function>""",
+                """<xsl:value-of select="count((1,4,6,8,3,5,6,2,1,3) ! f:make(.) | ())"/>"""))
+            .Should().Be(expected, "ten calls over seven distinct arguments");
+
+    [Fact]
+    public async Task NewEachTimeMaybe_IsAccepted()
+        => (await RunAsync(
+                $"""<xsl:function name="f:make" as="element()" new-each-time="maybe">{MakeNode}</xsl:function>""",
+                """<xsl:value-of select="count((1,1) ! f:make(.) | ())"/>"""))
+            .Should().BeOneOf("1", "2");
+
+    [Fact]
+    public async Task NewEachTime_RejectsANonBooleanValue()
+    {
+        var act = () => RunAsync(
+            $"""<xsl:function name="f:make" new-each-time="sometimes">{MakeNode}</xsl:function>""", "x");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTSE0020");
+    }
+
+    /// <summary>
+    /// Every pair here shared one cache entry under the old string key: a sequence argument
+    /// rendered as "System.Object[]", a string and an integer rendered alike, and a comma inside
+    /// a string was indistinguishable from the argument separator.
+    /// </summary>
+    [Theory]
+    [InlineData("f:echo((1, 2))", "f:echo((3, 4))", "1 2", "3 4")]
+    [InlineData("f:echo('1')", "f:echo(1)", "xs:string", "xs:integer")]
+    [InlineData("f:echo2('a,b', 'c')", "f:echo2('a', 'b,c')", "a,b|c", "a|b,c")]
+    [InlineData("f:echo(map{'k': 1})", "f:echo(map{'k': 2})", "1", "2")]
+    [InlineData("f:echo([1])", "f:echo([2])", "1", "2")]
+    public async Task CacheYes_NeverReturnsAnotherCallsResult(string first, string second, string firstResult, string secondResult)
+    {
+        const string functions = """
+            <xsl:function name="f:echo" cache="yes">
+              <xsl:param name="v"/>
+              <xsl:sequence select="if ($v instance of map(*)) then string($v?k)
+                                    else if ($v instance of array(*)) then string($v(1))
+                                    else if (count($v) = 1 and not($v instance of xs:integer)) then 'xs:string'
+                                    else if ($v instance of xs:integer) then 'xs:integer'
+                                    else string-join($v ! string(.), ' ')"/>
+            </xsl:function>
+            <xsl:function name="f:echo2" cache="yes">
+              <xsl:param name="a"/><xsl:param name="b"/>
+              <xsl:sequence select="$a || '|' || $b"/>
+            </xsl:function>
+            """;
+        (await RunAsync(functions, $"""<xsl:value-of select="{first}, '#', {second}" separator=""/>"""))
+            .Should().Be($"{firstResult}#{secondResult}");
+    }
+
+    [Fact]
+    public async Task CacheYes_StillHitsForEqualArguments()
+    {
+        // The memo is keyed by content for maps: two separately built but equal maps are the
+        // same call, so a node-returning function hands back the same node.
+        var result = await RunAsync(
+            """<xsl:function name="f:make" cache="yes"><xsl:param name="m"/><e><xsl:value-of select="$m?k"/></e></xsl:function>""",
+            """<xsl:value-of select="count((f:make(map{'k': 1}), f:make(map{'k': 1})) | ())"/>""");
+        result.Should().Be("1");
+    }
+}


### PR DESCRIPTION
### new-each-time="no"
`new-each-time="no"` declares a stylesheet function deterministic. Identical calls must return identical results, so a node the function builds is the same node every time (XSLT 3.0 §10.3.2). The attribute was parsed and validated but never acted on:

```xml
<xsl:function name="f:make" as="element()" new-each-time="no">
  <xsl:param name="n"/><e><xsl:value-of select="$n"/></e>
</xsl:function>
count((1,4,6,8,3,5,6,2,1,3) ! f:make(.) | ())   <!-- was 10; spec: 7 -->
```
It now uses the memo that `cache="yes"` already had. This fixes W3C **function-1025/1026**. The `yes` and `maybe` cases (1027–1030) still pass.

### The memo key was not an identity
The cache keyed each call by concatenating the arguments' text forms. Every row below shared one cache entry, so the second call returned the first call's result:

| call A | call B | why they collided |
|---|---|---|
| `f((1, 2))` | `f((3, 4))` | a sequence rendered as `System.Object[]` |
| `f('1')` | `f(1)` | string and integer render alike |
| `f2('a,b', 'c')` | `f2('a', 'b,c')` | a comma in a string reads as the argument separator |

Nodes were also told apart by `RuntimeHelpers.GetHashCode`, which distinct nodes can share. The new `FunctionMemoKey` compares nodes and function items by identity, atomics by type and value, and maps and arrays by content (as before).

### Boolean synonyms
`new-each-time` has type `xsl:yes-or-no-or-maybe`, so `true`/`1` and `false`/`0` are synonyms (W3C XSLT 3.0 schema). The parser rejected them with XTSE0020. It now normalizes them.

### Evidence
- Full XSLT sweep on the same checkout: **10,158 → 10,160**, with zero per-set losses.
- 13 new tests in `FunctionMemoizationTests`. **7 fail on the old code**: all three key collisions, `no`/`false`/`0`, and `true`. The other 6 are guards for the `yes`/`maybe`/invalid-value handling and the content-equal-map hit. The XSLT unit suite passes on net10.0: 1,503 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn