### PR TITLE
fix: XSLT built-ins declare their spec parameter cardinalities

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/XsltDocument2Function.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltDocument2Function.cs
@@ -31,7 +31,7 @@ internal sealed class XsltDocument2Function : PhoenixmlDb.XQuery.Ast.XQueryFunct
     };
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "uri-sequence"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalString },
+        new() { Name = new QName(NamespaceId.None, "uri-sequence"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.ZeroOrMoreItems },
         new() { Name = new QName(NamespaceId.None, "base-node"), Type = new PhoenixmlDb.XQuery.Ast.XdmSequenceType { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Node, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ExactlyOne } }
     ];
 

--- a/src/PhoenixmlDb.Xslt/Engine/XsltDocumentFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltDocumentFunction.cs
@@ -31,7 +31,7 @@ internal sealed class XsltDocumentFunction : PhoenixmlDb.XQuery.Ast.XQueryFuncti
     };
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "uri-sequence"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalString }
+        new() { Name = new QName(NamespaceId.None, "uri-sequence"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.ZeroOrMoreItems }
     ];
 
     public override ValueTask<object?> InvokeAsync(

--- a/src/PhoenixmlDb.Xslt/Engine/XsltFormatNumber3Function.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltFormatNumber3Function.cs
@@ -29,7 +29,7 @@ internal sealed class XsltFormatNumber3Function : PhoenixmlDb.XQuery.Ast.XQueryF
     public override PhoenixmlDb.XQuery.Ast.XdmSequenceType ReturnType => PhoenixmlDb.XQuery.Ast.XdmSequenceType.String;
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "value"), Type = new PhoenixmlDb.XQuery.Ast.XdmSequenceType { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Double, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ExactlyOne } },
+        new() { Name = new QName(NamespaceId.None, "value"), Type = new PhoenixmlDb.XQuery.Ast.XdmSequenceType { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Double, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ZeroOrOne } },
         new() { Name = new QName(NamespaceId.None, "picture"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.String },
         new() { Name = new QName(NamespaceId.None, "decimal-format-name"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalString }
     ];

--- a/src/PhoenixmlDb.Xslt/Engine/XsltFormatNumberFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltFormatNumberFunction.cs
@@ -29,7 +29,7 @@ internal sealed class XsltFormatNumberFunction : PhoenixmlDb.XQuery.Ast.XQueryFu
     public override PhoenixmlDb.XQuery.Ast.XdmSequenceType ReturnType => PhoenixmlDb.XQuery.Ast.XdmSequenceType.String;
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "value"), Type = new PhoenixmlDb.XQuery.Ast.XdmSequenceType { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Double, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ExactlyOne } },
+        new() { Name = new QName(NamespaceId.None, "value"), Type = new PhoenixmlDb.XQuery.Ast.XdmSequenceType { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Double, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ZeroOrOne } },
         new() { Name = new QName(NamespaceId.None, "picture"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.String }
     ];
 

--- a/src/PhoenixmlDb.Xslt/Engine/XsltJsonToXml2Function.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltJsonToXml2Function.cs
@@ -29,7 +29,7 @@ internal sealed class XsltJsonToXml2Function : PhoenixmlDb.XQuery.Ast.XQueryFunc
     public override PhoenixmlDb.XQuery.Ast.XdmSequenceType ReturnType => new() { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Node, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ZeroOrOne };
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.String },
+        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalString },
         new() { Name = new QName(NamespaceId.None, "options"), Type = new PhoenixmlDb.XQuery.Ast.XdmSequenceType { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Item, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ZeroOrOne } }
     ];
 

--- a/src/PhoenixmlDb.Xslt/Engine/XsltJsonToXmlFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltJsonToXmlFunction.cs
@@ -30,7 +30,7 @@ internal sealed class XsltJsonToXmlFunction : PhoenixmlDb.XQuery.Ast.XQueryFunct
     public override PhoenixmlDb.XQuery.Ast.XdmSequenceType ReturnType => new() { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Node, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ZeroOrOne };
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.String }
+        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalString }
     ];
 
     public override ValueTask<object?> InvokeAsync(

--- a/src/PhoenixmlDb.Xslt/Engine/XsltParseJson2Function.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltParseJson2Function.cs
@@ -29,7 +29,7 @@ internal sealed class XsltParseJson2Function : PhoenixmlDb.XQuery.Ast.XQueryFunc
     public override PhoenixmlDb.XQuery.Ast.XdmSequenceType ReturnType => PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalItem;
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.String },
+        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalString },
         new() { Name = new QName(NamespaceId.None, "options"), Type = new PhoenixmlDb.XQuery.Ast.XdmSequenceType { ItemType = PhoenixmlDb.XQuery.Ast.ItemType.Item, Occurrence = PhoenixmlDb.XQuery.Ast.Occurrence.ZeroOrOne } }
     ];
 

--- a/src/PhoenixmlDb.Xslt/Engine/XsltParseJsonFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltParseJsonFunction.cs
@@ -30,7 +30,7 @@ internal sealed class XsltParseJsonFunction : PhoenixmlDb.XQuery.Ast.XQueryFunct
     public override PhoenixmlDb.XQuery.Ast.XdmSequenceType ReturnType => PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalItem;
     public override IReadOnlyList<PhoenixmlDb.XQuery.Ast.FunctionParameterDef> Parameters =>
     [
-        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.String }
+        new() { Name = new QName(NamespaceId.None, "json-text"), Type = PhoenixmlDb.XQuery.Ast.XdmSequenceType.OptionalString }
     ];
 
     public override ValueTask<object?> InvokeAsync(

--- a/src/PhoenixmlDb.Xslt/Engine/XsltStreamAvailableFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltStreamAvailableFunction.cs
@@ -27,7 +27,7 @@ internal sealed class XsltStreamAvailableFunction : PhoenixmlDb.XQuery.Ast.XQuer
     public override QName Name => new(PhoenixmlDb.XQuery.Functions.FunctionNamespaces.Fn, "stream-available");
     public override XdmSequenceType ReturnType => XdmSequenceType.Boolean;
     public override IReadOnlyList<FunctionParameterDef> Parameters =>
-        [new() { Name = new QName(NamespaceId.None, "uri"), Type = XdmSequenceType.String }];
+        [new() { Name = new QName(NamespaceId.None, "uri"), Type = XdmSequenceType.OptionalString }];
 
     public override async ValueTask<object?> InvokeAsync(
         IReadOnlyList<object?> arguments,

--- a/tests/PhoenixmlDb.Xslt.Tests/XsltBuiltinSignatureTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/XsltBuiltinSignatureTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// The XSLT library's built-in functions declare the parameter cardinalities of the XSLT 3.0 and
+/// F&amp;O 3.1 signatures. Several were declared exactly-one or <c>xs:string?</c> where the spec
+/// admits more. Invocation never checked, so calls worked, but the declared signature is what a
+/// function item carries: <c>document#1</c> was not an instance of <c>function(item()*) as
+/// item()*</c>. A cardinality check at the call site would turn each of them into a rejected
+/// valid call — <c>document(/xxx/ref/@file)</c> over two attributes raised XPTY0004 (W3C
+/// document-0105 and 18 more, bug-2701).
+/// </summary>
+public sealed class XsltBuiltinSignatureTests
+{
+    private static async Task<string> EvalAsync(string xpath)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+              <xsl:output method="text"/>
+              <xsl:template match="/"><xsl:value-of select="{xpath}"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("document#1 instance of function(item()*) as item()*")]
+    [InlineData("document#2 instance of function(item()*, node()) as item()*")]
+    [InlineData("parse-json#1 instance of function(xs:string?) as item()?")]
+    [InlineData("json-to-xml#1 instance of function(xs:string?) as item()?")]
+    [InlineData("stream-available#1 instance of function(xs:string?) as xs:boolean")]
+    public async Task ABuiltin_IsAnInstanceOfItsSpecSignature(string test)
+        => (await EvalAsync(test)).Should().Be("true");
+
+    [Theory]
+    [InlineData("parse-json(())", "")]
+    [InlineData("json-to-xml(())", "")]
+    [InlineData("format-number((), '0')", "NaN")]
+    [InlineData("stream-available(())", "false")]
+    public async Task AnEmptyArgumentTheSpecAllows_IsAccepted(string call, string expected)
+        => (await EvalAsync(call)).Should().Be(expected);
+}


### PR DESCRIPTION
Nine parameters in the XSLT function library were declared stricter than the XSLT 3.0 / F&O 3.1 signatures:

| function | parameter | declared | spec |
|---|---|---|---|
| `document#1`, `#2` | `$uri-sequence` | `xs:string?` | `item()*` |
| `format-number#2`, `#3` | `$value` | `xs:double` (exactly one) | `xs:numeric?` |
| `json-to-xml#1`, `#2` | `$json-text` | `xs:string` | `xs:string?` |
| `parse-json#1`, `#2` | `$json-text` | `xs:string` | `xs:string?` |
| `stream-available#1` | `$uri` | `xs:string` | `xs:string?` |

Invocation never checked cardinality, so direct calls worked. But the declared signature is what a function item carries, so `document#1` was not an instance of `function(item()*) as item()*`.

**Why now.** This prepares for an xquery change that applies the cardinality half of the function conversion rules to built-in calls (`substring('abc', ())` currently returns `""` rather than XPTY0004). With the old declarations, that check rejects valid calls: `document(/xxx/ref/@file)` over two attributes raised XPTY0004 in 20 W3C cases (document-0105 and 18 more, plus bug-2701). The audit behind this compared every parameter against the XSLT 3.0 / F&O 3.1 signatures, and these nine are the only mismatches.

Only occurrence changes. Item types are untouched: `format-number`'s `$value` is still `xs:double` rather than `xs:numeric`, which is a separate change.

### Evidence
- XSLT sweep on the same checkout, with xquery at main: **10,158**, zero per-set losses. The declarations are harmless on their own.
- With the xquery check applied as well, the only remaining XSLT loss is accumulator-077. That's a separate accumulator-ordering bug the lenient `map:put` was hiding, and it gets its own PR.
- 9 new tests. **5 fail on the old code** (the signature `instance of` checks). The other 4 guard the empty-argument calls. The XSLT unit suite passes on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn