### PR TITLE
test: raise the baseline for #20 and #21 — XSLT 10,160

### DIFF
--- a/scripts/conformance-baseline.tsv
+++ b/scripts/conformance-baseline.tsv
@@ -439,7 +439,7 @@ tests/decl/accumulator/_accumulator-test-set.xml	82	103
 tests/decl/attribute-set/_attribute-set-test-set.xml	48	49
 tests/decl/character-map/_character-map-test-set.xml	28	29
 tests/decl/context-item/_context-item-test-set.xml	24	31
-tests/decl/function/_function-test-set.xml	96	104
+tests/decl/function/_function-test-set.xml	99	104
 tests/decl/global-context-item/_global-context-item-test-set.xml	12	14
 tests/decl/import/_import-test-set.xml	40	40
 tests/decl/include/_include-test-set.xml	13	15


### PR DESCRIPTION
Raises `decl/function` in `scripts/conformance-baseline.tsv` from 96 to 99, taking the XSLT baseline from **10,157 to 10,160**:
- function-1022, fixed by #20: a function's result lost its text, or was doubled inside a variable.
- function-1025/1026, fixed by #21: `new-each-time="no"` now memoizes.

Without this raise, the per-set gate defends 10,157, so a regression back to 10,157 would pass silently.

**Method:** the same rule as #19. I took the minimum of two full `--all` runs on main (xslt be614ad, xquery fb86490) and raised a set only where both runs agree above the old value. `insn/call-template` gave 37 and then 38, so it stays at its floor of 37; that's the deep-recursion pair, still flickering. QT3 is unchanged at 29,524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn