### PR TITLE
fix: an accumulator rule sees the other accumulator's value for THIS node

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Streaming.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Streaming.cs
@@ -522,95 +522,205 @@ internal sealed partial class DefaultXsltExecutionContext
             IdPatternEvaluator = _matchCtxIdPatternEvaluator,
         };
 
-        // Evaluate start-phase rules for ALL accumulators at this node.
-        // Store before-values incrementally so cross-accumulator references
-        // (e.g., interval-1 calling accumulator-before('latest-1')) work correctly.
-        for (var i = 0; i < accumulators.Count; i++)
+        var frame = new AccumulatorWalkFrame(node, nodeId, matchContext, accumulators, currentValues, nodeValueMaps);
+        var savedFrame = _accumulatorWalkFrame;
+        _accumulatorWalkFrame = frame;
+        try
         {
-            // Skip evaluation if the accumulator is in error state
-            if (currentValues[i] is AccumulatorDeferredError)
+            // Start-phase rules for ALL accumulators at this node, in declaration order — but a
+            // rule that asks for another accumulator's value at this node runs that one first
+            // (see EnsureAccumulatorPhaseAsync), so declaration order never decides a value.
+            for (var i = 0; i < accumulators.Count; i++)
+                await RunAccumulatorStartPhaseAsync(frame, i).ConfigureAwait(false);
+
+            // Process children
+            IReadOnlyList<NodeId>? children = null;
+            if (node is XdmDocument d)
+                children = d.Children;
+            else if (node is XdmElement elem)
+                children = elem.Children;
+
+            if (children != null)
             {
-                nodeValueMaps[i][nodeId] = (before: currentValues[i], after: currentValues[i]);
+                foreach (var childId in children)
+                {
+                    var child = nodeStore.GetNode(childId);
+                    if (child != null)
+                        await WalkAccumulatorsAsync(child, accumulators, currentValues, nodeValueMaps, nodeStore).ConfigureAwait(false);
+                }
+            }
+
+            // End-phase rules for ALL accumulators at this node, on the same terms.
+            frame.InEndPhase = true;
+            for (var i = 0; i < accumulators.Count; i++)
+                await RunAccumulatorEndPhaseAsync(frame, i).ConfigureAwait(false);
+        }
+        finally
+        {
+            _accumulatorWalkFrame = savedFrame;
+        }
+    }
+
+
+    /// <summary>The accumulator walk's state at the node it is visiting.</summary>
+    /// <remarks>
+    /// Exists so a rule can ask for another accumulator's value at the SAME node before the walk
+    /// has reached that accumulator. Each phase ran accumulators in declaration order and stored
+    /// values as it went, so an end rule reading a later-declared accumulator's after-value got
+    /// the provisional entry the start phase left — the value from BEFORE this node's
+    /// descendants. W3C accumulator-077: header-map's end rule on header-item read
+    /// accumulator-after('header-id') and got the previous header-item's id, () for the first.
+    /// </remarks>
+    private sealed class AccumulatorWalkFrame(
+        object node,
+        NodeId nodeId,
+        XsltContext matchContext,
+        IReadOnlyList<XsltAccumulator> accumulators,
+        object?[] currentValues,
+        Dictionary<NodeId, (object? before, object? after)>[] nodeValueMaps)
+    {
+        public object Node { get; } = node;
+        public NodeId NodeId { get; } = nodeId;
+        public XsltContext MatchContext { get; } = matchContext;
+        public IReadOnlyList<XsltAccumulator> Accumulators { get; } = accumulators;
+        public object?[] CurrentValues { get; } = currentValues;
+        public Dictionary<NodeId, (object? before, object? after)>[] NodeValueMaps { get; } = nodeValueMaps;
+        public bool InEndPhase { get; set; }
+        /// <summary>Per accumulator: 0 = not run in the current phase, 1 = running, 2 = done.</summary>
+        public byte[] StartState { get; } = new byte[accumulators.Count];
+        public byte[] EndState { get; } = new byte[accumulators.Count];
+    }
+
+
+    private AccumulatorWalkFrame? _accumulatorWalkFrame;
+
+
+    private async ValueTask RunAccumulatorStartPhaseAsync(AccumulatorWalkFrame frame, int i)
+    {
+        if (frame.StartState[i] != 0)
+            return;
+        frame.StartState[i] = 1;
+        var currentValues = frame.CurrentValues;
+        // Skip evaluation if the accumulator is in error state
+        if (currentValues[i] is AccumulatorDeferredError)
+        {
+            frame.NodeValueMaps[i][frame.NodeId] = (before: currentValues[i], after: currentValues[i]);
+            frame.StartState[i] = 2;
+            return;
+        }
+
+        var acc = frame.Accumulators[i];
+        foreach (var rule in acc.Rules)
+        {
+            if (rule.Phase != AccumulatorPhase.Start)
                 continue;
-            }
+            if (!rule.Match.Matches(frame.Node, frame.MatchContext))
+                continue;
 
-            var acc = accumulators[i];
-            foreach (var rule in acc.Rules)
+            try
             {
-                if (rule.Phase != AccumulatorPhase.Start)
-                    continue;
-                if (!rule.Match.Matches(node, matchContext))
-                    continue;
-
-                try
-                {
-                    currentValues[i] = await EvaluateAccumulatorRuleAsync(
-                        node, rule, currentValues[i], acc).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (AccumulatorDeferredError.IsDeferrable(ex))
-                {
-                    currentValues[i] = new AccumulatorDeferredError(ex);
-                }
-                break; // Only first matching rule fires
+                currentValues[i] = await EvaluateAccumulatorRuleAsync(
+                    frame.Node, rule, currentValues[i], acc).ConfigureAwait(false);
             }
-
-            // Store before-value immediately so other accumulators can reference it
-            nodeValueMaps[i][nodeId] = (before: currentValues[i], after: currentValues[i]);
+            catch (Exception ex) when (AccumulatorDeferredError.IsDeferrable(ex))
+            {
+                currentValues[i] = new AccumulatorDeferredError(ex);
+            }
+            break; // Only first matching rule fires
         }
 
-        // Process children
-        IReadOnlyList<NodeId>? children = null;
-        if (node is XdmDocument d)
-            children = d.Children;
-        else if (node is XdmElement elem)
-            children = elem.Children;
+        // Store before-value immediately so other accumulators can reference it
+        frame.NodeValueMaps[i][frame.NodeId] = (before: currentValues[i], after: currentValues[i]);
+        frame.StartState[i] = 2;
+    }
 
-        if (children != null)
+
+    private async ValueTask RunAccumulatorEndPhaseAsync(AccumulatorWalkFrame frame, int i)
+    {
+        if (frame.EndState[i] != 0)
+            return;
+        frame.EndState[i] = 1;
+        var currentValues = frame.CurrentValues;
+        // Skip evaluation if the accumulator is in error state
+        if (currentValues[i] is AccumulatorDeferredError)
         {
-            foreach (var childId in children)
-            {
-                var child = nodeStore.GetNode(childId);
-                if (child != null)
-                    await WalkAccumulatorsAsync(child, accumulators, currentValues, nodeValueMaps, nodeStore).ConfigureAwait(false);
-            }
+            frame.EndState[i] = 2;
+            return;
         }
 
-        // Evaluate end-phase rules for ALL accumulators at this node.
-        // Update after-values incrementally so cross-accumulator references work.
         _evaluatingAccEndPhase ??= new();
-        for (var i = 0; i < accumulators.Count; i++)
+        var acc = frame.Accumulators[i];
+        foreach (var rule in acc.Rules)
         {
-            // Skip evaluation if the accumulator is in error state
-            if (currentValues[i] is AccumulatorDeferredError)
+            if (rule.Phase != AccumulatorPhase.End)
+                continue;
+            if (!rule.Match.Matches(frame.Node, frame.MatchContext))
                 continue;
 
-            var acc = accumulators[i];
-            foreach (var rule in acc.Rules)
+            var cycleKey = (acc.Name, frame.NodeId);
+            _evaluatingAccEndPhase.Add(cycleKey);
+            try
             {
-                if (rule.Phase != AccumulatorPhase.End)
-                    continue;
-                if (!rule.Match.Matches(node, matchContext))
-                    continue;
-
-                var cycleKey = (acc.Name, nodeId);
-                _evaluatingAccEndPhase.Add(cycleKey);
-                try
-                {
-                    currentValues[i] = await EvaluateAccumulatorRuleAsync(
-                        node, rule, currentValues[i], acc).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (AccumulatorDeferredError.IsDeferrable(ex))
-                {
-                    currentValues[i] = new AccumulatorDeferredError(ex);
-                }
-                finally
-                {
-                    _evaluatingAccEndPhase.Remove(cycleKey);
-                }
-                break; // Only first matching rule fires
+                currentValues[i] = await EvaluateAccumulatorRuleAsync(
+                    frame.Node, rule, currentValues[i], acc).ConfigureAwait(false);
             }
-            // Update this accumulator's after-value immediately so subsequent accumulators can see it
-            nodeValueMaps[i][nodeId] = (nodeValueMaps[i][nodeId].before, after: currentValues[i]);
+            catch (Exception ex) when (AccumulatorDeferredError.IsDeferrable(ex))
+            {
+                currentValues[i] = new AccumulatorDeferredError(ex);
+            }
+            finally
+            {
+                _evaluatingAccEndPhase.Remove(cycleKey);
+            }
+            break; // Only first matching rule fires
+        }
+        // Update this accumulator's after-value immediately so subsequent accumulators can see it
+        frame.NodeValueMaps[i][frame.NodeId] = (frame.NodeValueMaps[i][frame.NodeId].before, after: currentValues[i]);
+        frame.EndState[i] = 2;
+    }
+
+
+    /// <summary>
+    /// Before a rule reads another accumulator's value at the node the walk is visiting, runs
+    /// that accumulator's rule for the current phase if it has not run yet.
+    /// </summary>
+    /// <remarks>
+    /// accumulator-before needs the start phase done; accumulator-after, read from an end rule,
+    /// needs the end phase done. A request for an accumulator whose rule is running at this node
+    /// is a cycle among the accumulators, XTDE3400 — the end-phase case was already reported by
+    /// <see cref="GetAccumulatorValue"/>, and a start-phase cycle would otherwise read a value
+    /// that does not exist yet.
+    /// </remarks>
+    internal async ValueTask EnsureAccumulatorPhaseAsync(QName accumulatorName, object node, bool isAfter)
+    {
+        if (_accumulatorWalkFrame is not { } frame)
+            return;
+        var nodeId = node switch { XdmDocument d => d.Id, XdmNode n => n.Id, _ => (NodeId?)null };
+        if (nodeId != frame.NodeId)
+            return;
+        var index = -1;
+        for (var i = 0; i < frame.Accumulators.Count; i++)
+        {
+            if (frame.Accumulators[i].Name.Equals(accumulatorName))
+            {
+                index = i;
+                break;
+            }
+        }
+        if (index < 0)
+            return;
+
+        if (!frame.InEndPhase)
+        {
+            if (isAfter)
+                return;
+            if (frame.StartState[index] == 1)
+                throw Error($"XTDE3400: Cyclic dependency detected in accumulator '{accumulatorName}' at the current node");
+            await RunAccumulatorStartPhaseAsync(frame, index).ConfigureAwait(false);
+        }
+        else if (isAfter && frame.EndState[index] == 0)
+        {
+            await RunAccumulatorEndPhaseAsync(frame, index).ConfigureAwait(false);
         }
     }
 

--- a/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorAfterFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorAfterFunction.cs
@@ -57,6 +57,7 @@ internal sealed class XsltAccumulatorAfterFunction : PhoenixmlDb.XQuery.Ast.XQue
 
         // Lazily compute accumulators for this document if not yet done
         await _context.EnsureAccumulatorsComputedAsync(accName, node).ConfigureAwait(false);
+        await _context.EnsureAccumulatorPhaseAsync(accName, node, isAfter: true).ConfigureAwait(false);
 
         var values = _context.GetAccumulatorValue(accName, node, isAfter: true)
             ?? throw new XsltException($"XTDE3340: No accumulator named '{name}' is available for the current node");

--- a/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
@@ -57,6 +57,7 @@ internal sealed class XsltAccumulatorBeforeFunction : PhoenixmlDb.XQuery.Ast.XQu
 
         // Lazily compute accumulators for this document if not yet done
         await _context.EnsureAccumulatorsComputedAsync(accName, node).ConfigureAwait(false);
+        await _context.EnsureAccumulatorPhaseAsync(accName, node, isAfter: false).ConfigureAwait(false);
 
         var values = _context.GetAccumulatorValue(accName, node)
             ?? throw new XsltException($"XTDE3340: No accumulator named '{name}' is available for the current node");

--- a/tests/PhoenixmlDb.Xslt.Tests/AccumulatorDependencyOrderTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/AccumulatorDependencyOrderTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// An accumulator rule that reads another accumulator's value at the same node must see that
+/// accumulator's value for THIS node, whichever was declared first. The walk ran each phase in
+/// declaration order and stored values as it went, so a rule reading a later-declared
+/// accumulator got the provisional entry: from an end rule, the value before this node's
+/// descendants — the previous node's. Silent wrong data; W3C accumulator-077 passed only because
+/// its one lookup hit the entry written one item late.
+/// </summary>
+public sealed class AccumulatorDependencyOrderTests
+{
+    private const string Source = "<r><i><id>1</id></i><i><id>2</id></i><i><id>3</id></i></r>";
+
+    private static async Task<string> RunAsync(string accumulators, string body)
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:mode use-accumulators="#all"/>
+              {{accumulators}}
+              <xsl:template match="/">{{body}}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync(Source)).Trim();
+    }
+
+    // "seen" reads "last-id" from its end rule on each <i>: the ids seen so far, in order.
+    private const string Seen = """
+        <xsl:accumulator name="seen" as="xs:integer*" initial-value="()">
+          <xsl:accumulator-rule match="i" phase="end" select="$value, accumulator-after('last-id')"/>
+        </xsl:accumulator>
+        """;
+
+    private const string LastId = """
+        <xsl:accumulator name="last-id" as="xs:integer?" initial-value="()">
+          <xsl:accumulator-rule match="i/id/text()" select="xs:integer(.)"/>
+        </xsl:accumulator>
+        """;
+
+    [Theory]
+    [InlineData(Seen + LastId)] // the reader declared first — the order that was wrong
+    [InlineData(LastId + Seen)] // the reader declared second — the order that already worked
+    public async Task AnEndRule_SeesTheOtherAccumulatorsValueForThisNode(string accumulators)
+        => (await RunAsync(accumulators, """<xsl:value-of select="/r/accumulator-after('seen')"/>"""))
+            .Should().Be("1 2 3", "the previous item's id, and () for the first, was the defect");
+
+    [Theory]
+    [InlineData("first")]
+    [InlineData("second")]
+    public async Task AStartRule_SeesTheOtherAccumulatorsBeforeValueForThisNode(string readerPosition)
+    {
+        // "count" numbers each <i> at its start; "tagged" records that number at the same <i>.
+        const string counter = """
+            <xsl:accumulator name="count" as="xs:integer" initial-value="0">
+              <xsl:accumulator-rule match="i" phase="start" select="$value + 1"/>
+            </xsl:accumulator>
+            """;
+        const string tagged = """
+            <xsl:accumulator name="tagged" as="xs:integer*" initial-value="()">
+              <xsl:accumulator-rule match="i" phase="start" select="$value, accumulator-before('count')"/>
+            </xsl:accumulator>
+            """;
+        var accumulators = readerPosition == "first" ? tagged + counter : counter + tagged;
+        (await RunAsync(accumulators, """<xsl:value-of select="/r/accumulator-after('tagged')"/>"""))
+            .Should().Be("1 2 3");
+    }
+
+    /// <summary>
+    /// The old walk missed this cycle entirely: the cycle check caught an accumulator reading
+    /// itself, but here a's end rule read b's provisional entry and finished, and b then read a's
+    /// fresh value — a value came out, no error. Evaluating b on demand from inside a's rule is
+    /// what exposes the cycle.
+    /// </summary>
+    [Fact]
+    public async Task ACycleBetweenTwoAccumulators_IsXTDE3400()
+    {
+        const string cycle = """
+            <xsl:accumulator name="a" initial-value="0">
+              <xsl:accumulator-rule match="i" phase="end" select="accumulator-after('b')"/>
+            </xsl:accumulator>
+            <xsl:accumulator name="b" initial-value="0">
+              <xsl:accumulator-rule match="i" phase="end" select="accumulator-after('a')"/>
+            </xsl:accumulator>
+            """;
+        var act = () => RunAsync(cycle, """<xsl:value-of select="/r/accumulator-after('a')"/>""");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTDE3400");
+    }
+}


### PR DESCRIPTION
### The defect
`WalkAccumulatorsAsync` ran each phase's rules in **declaration order** and stored values as it went. The comment above the loop says this makes cross-accumulator references work, but it only works in one direction: a later-declared accumulator reading an earlier one. When a rule read a later-declared accumulator at the same node, it got the provisional entry the start phase had left. From an end rule, that's the value from before this node's descendants, which is the previous node's value.

Which answer came out depended on declaration order, which no author has reason to think is significant. The output was silently wrong, with no error. This dates to the initial commit.

W3C **accumulator-077** passed only by coincidence. `header-map`'s end rule reads `accumulator-after('header-id')` on each `header-item`. It got the *previous* item's id, and `()` for the first. The stylesheet's single lookup (`idref="1"`) happened to hit the entry written one item late. A call-site cardinality check exposed it by rejecting `map:put` with an empty key. Traced:
```
before:  KEY at header-item[1]: ()    KEY at header-item[2]: 1
after:   KEY at header-item[1]: 1     KEY at header-item[2]: 2
```

### The fix
Each node's walk keeps a frame recording the phase and per-accumulator progress. A rule that asks for another accumulator's value at that node (`accumulator-before` in the start phase, `accumulator-after` in the end phase) now runs that accumulator's rule first, through `EnsureAccumulatorPhaseAsync`.

It evaluates on demand rather than doing a topological sort, because accumulator names can be computed at run time, so the declaration graph doesn't show every edge. A request for an accumulator whose rule is already running at the node is **XTDE3400**. That also catches a two-accumulator cycle the old walk missed entirely: `a` read `b`'s provisional value and finished, and no error was raised.

### Evidence
- Full XSLT sweep on the same checkout: **10,160 → 10,162**, with zero per-set losses. The gains are **accumulator-079** and **error-3400a** (the W3C XTDE3400 cycle case).
- 5 new tests in `AccumulatorDependencyOrderTests`, of which **3 fail on the old code**:
  - The reader-first end rule gives `1 2` instead of `1 2 3`.
  - The reader-first start rule gives nothing.
  - The two-accumulator cycle raises no error.

  The reader-second variants are guards for the order that already worked. The XSLT unit suite passes on net10.0: 1,510 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn