### PR TITLE
fix(harness): the per-set gate reports a baselined set that produced no result

### DIFF
--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -337,6 +337,39 @@ elif [ -f "$BASELINE" ]; then
   ' "$BASELINE" "$CURRENT")"
   newsets="$(awk -F'\t' 'NR==FNR{base[$1]=1; next} !($1 in base){printf "  %s (%d/%d)\n", $1, $2, $3}' \
               "$BASELINE" "$CURRENT")"
+  # A baselined set this run should have covered but that reported NO result. The checks above
+  # all iterate CURRENT, so a set that never ran was never visited: when strm3's test host
+  # crashed, sx-GeneralComp-le/-ne vanished and the per-set section said nothing (BUGS.md #54).
+  # A set with no verdict is worse news than a set with a lower count, so it fails the run too.
+  #
+  # Only sets whose chunk ran are expected — a single-chunk run must not flag the rest of the
+  # baseline. Ownership: a QT3 set (no tests/ prefix) belongs to xqts; tests/<g>/ belongs to
+  # chunk <g>; the strm sub-chunks list their sets in their test classes, read from source here
+  # so there is no second copy of that list to drift.
+  EXPECTED_STRM="$OUT/per-set-expected-strm.txt"
+  : > "$EXPECTED_STRM"
+  for n in 1 2 3; do
+    case " ${CHUNKS[*]} " in *" strm$n "*) ;; *) continue ;; esac
+    cls="$PROJ/Xslt/XsltStreamingTests$([ $n -eq 1 ] || echo $n).cs"
+    listed="$(grep -o 'InlineData("tests/strm/[^"]*")' "$cls" 2>/dev/null | sed 's/^InlineData("//; s/")$//')"
+    # Fail closed: a renamed class or a reshaped attribute would otherwise yield an empty list,
+    # and this check would go blind for strm$n without saying so.
+    if [ -z "$listed" ]; then
+      echo "PER-SET CHECK BROKEN — could not read strm$n's test-set list from $cls" | tee -a "$OUT/summary.txt"
+      failed=1
+    fi
+    printf '%s\n' "$listed" >> "$EXPECTED_STRM"
+  done
+  noresult="$(awk -F'\t' -v ran=" ${CHUNKS[*]} " '
+    FILENAME == ARGV[1] { strm[$1] = 1; next }
+    FILENAME == ARGV[2] { cur[$1] = 1; next }
+    {
+      if ($1 !~ /^tests\//)          owned = index(ran, " xqts ") > 0
+      else if ($1 ~ /^tests\/strm\//) owned = ($1 in strm)
+      else { split($1, p, "/");       owned = index(ran, " " p[2] " ") > 0 }
+      if (owned && !($1 in cur)) printf "  %s: baselined %d, NO RESULT this run\n", $1, $2
+    }
+  ' "$EXPECTED_STRM" "$CURRENT" "$BASELINE")"
   [ -n "$gained" ]  && { echo "per-set GAINS:"    | tee -a "$OUT/summary.txt"; echo "$gained"  | tee -a "$OUT/summary.txt"; }
   [ -n "$newsets" ] && { echo "per-set NEW sets:" | tee -a "$OUT/summary.txt"; echo "$newsets" | tee -a "$OUT/summary.txt"; }
   if [ -n "$regressed" ]; then
@@ -344,6 +377,12 @@ elif [ -f "$BASELINE" ]; then
     echo "$regressed" | tee -a "$OUT/summary.txt"
     echo "If the drop is intended, re-run with CONFORMANCE_UPDATE_BASELINE=1 to re-baseline." |
       tee -a "$OUT/summary.txt"
+    failed=1
+  fi
+  if [ -n "$noresult" ]; then
+    echo "PER-SET NO RESULT — baselined test-sets this run should have covered did not report:" |
+      tee -a "$OUT/summary.txt"
+    echo "$noresult" | tee -a "$OUT/summary.txt"
     failed=1
   fi
 else


### PR DESCRIPTION
Fixes BUGS.md #54, which the parsers session found and reproduced.

### The blind spot
Every per-set check in `conformance.sh` (regressed, gained, new sets) iterates the **current** run and looks each set up in the baseline. A baselined set that never ran is therefore never visited. When strm3's test host crashed with SIGSEGV during a baseline run (xslt#25), `sx-GeneralComp-le` and `-ne` vanished, and the per-set section said nothing. "Unexamined" read as "clean". The chunk line did flag the crash; the per-set section, which is where a reader looks for "did anything regress?", did not.

### The fix
A baselined set whose chunk ran but which reported no `Results:` line is listed under **PER-SET NO RESULT** and fails the run. No verdict is worse news than a lower count.

The check is scoped to the chunks that actually ran, so a single-chunk run doesn't flag the rest of the baseline:
- QT3 sets (no `tests/` prefix) belong to `xqts`.
- `tests/<g>/` belongs to chunk `<g>`. I checked this against a full run: every chunk's sets are in its own directory.
- The strm sub-chunks' sets are read from the `InlineData` lists in `XsltStreamingTests{,2,3}.cs`, which is the same list the tests run rather than a second copy. If that list can't be read, the check **fails closed** instead of going blind.

### Checked
The block was driven against recorded runs:

| run | reported |
|---|---|
| crashed `--all` (the xslt#25 run 1) | exactly `sx-GeneralComp-le` and `sx-GeneralComp-ne` |
| clean `--all`, strm3-only, xqts-only | nothing |
| strm3-only with `sx-UnionExpr` deleted | `sx-UnionExpr` |
| xqts-only with `fn-sum` deleted | `fn-sum` |
| chunk `strm1` given strm3's results | strm1's own sets, which shows ownership comes from the class lists |
| strm class file unreadable | `PER-SET CHECK BROKEN`, fails |

A real `./scripts/conformance.sh strm3` run exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn