### PR TITLE
fix: of several matching accumulator rules, the last in document order applies

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Streaming.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Streaming.cs
@@ -595,6 +595,30 @@ internal sealed partial class DefaultXsltExecutionContext
     private AccumulatorWalkFrame? _accumulatorWalkFrame;
 
 
+    /// <summary>
+    /// The rule an accumulator applies at a traversal event: of its rules for this phase whose
+    /// pattern matches the node, the one LAST in document order (XSLT 3.0 §18.2.4, "Let Q be the
+    /// xsl:accumulator-rule in R that is last in document order"). Priority plays no part.
+    /// </summary>
+    /// <remarks>
+    /// Every site took the FIRST match, so of two rules matching one node the earlier won —
+    /// W3C accumulator-081 gave 1 where the spec gives 2. One helper, so the in-memory walk and the
+    /// streaming processor cannot pick differently.
+    /// </remarks>
+    internal static XsltAccumulatorRule? SelectAccumulatorRule(
+        XsltAccumulator accumulator, AccumulatorPhase phase, object node, XsltContext matchContext)
+    {
+        var rules = accumulator.Rules;
+        for (var r = rules.Count - 1; r >= 0; r--)
+        {
+            var rule = rules[r];
+            if (rule.Phase == phase && rule.Match.Matches(node, matchContext))
+                return rule;
+        }
+        return null;
+    }
+
+
     private async ValueTask RunAccumulatorStartPhaseAsync(AccumulatorWalkFrame frame, int i)
     {
         if (frame.StartState[i] != 0)
@@ -610,13 +634,8 @@ internal sealed partial class DefaultXsltExecutionContext
         }
 
         var acc = frame.Accumulators[i];
-        foreach (var rule in acc.Rules)
+        if (SelectAccumulatorRule(acc, AccumulatorPhase.Start, frame.Node, frame.MatchContext) is { } rule)
         {
-            if (rule.Phase != AccumulatorPhase.Start)
-                continue;
-            if (!rule.Match.Matches(frame.Node, frame.MatchContext))
-                continue;
-
             try
             {
                 currentValues[i] = await EvaluateAccumulatorRuleAsync(
@@ -626,7 +645,6 @@ internal sealed partial class DefaultXsltExecutionContext
             {
                 currentValues[i] = new AccumulatorDeferredError(ex);
             }
-            break; // Only first matching rule fires
         }
 
         // Store before-value immediately so other accumulators can reference it
@@ -650,13 +668,8 @@ internal sealed partial class DefaultXsltExecutionContext
 
         _evaluatingAccEndPhase ??= new();
         var acc = frame.Accumulators[i];
-        foreach (var rule in acc.Rules)
+        if (SelectAccumulatorRule(acc, AccumulatorPhase.End, frame.Node, frame.MatchContext) is { } rule)
         {
-            if (rule.Phase != AccumulatorPhase.End)
-                continue;
-            if (!rule.Match.Matches(frame.Node, frame.MatchContext))
-                continue;
-
             var cycleKey = (acc.Name, frame.NodeId);
             _evaluatingAccEndPhase.Add(cycleKey);
             try
@@ -672,7 +685,6 @@ internal sealed partial class DefaultXsltExecutionContext
             {
                 _evaluatingAccEndPhase.Remove(cycleKey);
             }
-            break; // Only first matching rule fires
         }
         // Update this accumulator's after-value immediately so subsequent accumulators can see it
         frame.NodeValueMaps[i][frame.NodeId] = (frame.NodeValueMaps[i][frame.NodeId].before, after: currentValues[i]);

--- a/src/PhoenixmlDb.Xslt/Engine/StreamingXmlProcessor.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StreamingXmlProcessor.cs
@@ -1054,13 +1054,8 @@ internal sealed class StreamingXmlProcessor
             }
 
             var acc = _accumulators[i];
-            foreach (var rule in acc.Rules)
+            if (DefaultXsltExecutionContext.SelectAccumulatorRule(acc, phase, node, matchContext) is { } rule)
             {
-                if (rule.Phase != phase)
-                    continue;
-                if (!rule.Match.Matches(node, matchContext))
-                    continue;
-
                 try
                 {
                     _accCurrentValues[i] = await _context.EvaluateAccumulatorRuleAsync(
@@ -1070,7 +1065,6 @@ internal sealed class StreamingXmlProcessor
                 {
                     _accCurrentValues[i] = new AccumulatorDeferredError(ex);
                 }
-                break; // Only first matching rule fires
             }
 
             // Store values: start phase sets before-value, end phase updates after-value

--- a/tests/PhoenixmlDb.Xslt.Tests/AccumulatorRuleSelectionTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/AccumulatorRuleSelectionTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// When several of an accumulator's rules match a node in the same phase, the one LAST in
+/// document order applies (XSLT 3.0 §18.2.4: "Let Q be the xsl:accumulator-rule in R that is
+/// last in document order"). Priority plays no part. Every selection site took the first match;
+/// W3C accumulator-081 gave 1 where the spec gives 2.
+/// </summary>
+public sealed class AccumulatorRuleSelectionTests
+{
+    private static async Task<string> RunAsync(string rules, string phase = "start")
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:mode use-accumulators="#all"/>
+              <xsl:accumulator name="a" as="xs:string" initial-value="'none'">{{rules}}</xsl:accumulator>
+              <xsl:template match="/"><xsl:value-of select="/r/e/accumulator-after('a')"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<r><e/></r>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("""<xsl:accumulator-rule match="e" select="'first'"/><xsl:accumulator-rule match="e" select="'last'"/>""", "last")]
+    // Default priority does not decide it: the more specific pattern is FIRST here and still loses.
+    [InlineData("""<xsl:accumulator-rule match="r/e" select="'specific'"/><xsl:accumulator-rule match="*" select="'last'"/>""", "last")]
+    [InlineData("""<xsl:accumulator-rule match="*" select="'first'"/><xsl:accumulator-rule match="r/e" select="'last'"/>""", "last")]
+    // A later rule for the OTHER phase does not shadow an earlier one for this phase.
+    [InlineData("""<xsl:accumulator-rule match="e" select="'start'"/><xsl:accumulator-rule match="e" phase="end" select="$value || '+end'"/>""", "start+end")]
+    public async Task TheLastMatchingRuleInDocumentOrderApplies(string rules, string expected)
+        => (await RunAsync(rules)).Should().Be(expected);
+}


### PR DESCRIPTION
XSLT 3.0 §18.2.4 says: *"Let Q be the xsl:accumulator-rule in R that is last in document order"*, where R is the set of rules for the event's phase whose pattern matches the node. Priority plays no part.

All three selection sites took the **first** match: the in-memory walk's start and end phases, and the streaming processor. So when two rules matched one node, the earlier one won, and W3C **accumulator-081** gave `1` where the spec gives `2`. A single helper, `SelectAccumulatorRule`, now serves all three sites, so the in-memory and streaming paths can't pick differently.

### Evidence
- Full XSLT sweep on the same checkout: **10,163 → 10,164** (accumulator-081), with zero per-set losses. `insn/call-template` at 38 is its known flicker.
- 4 new tests in `AccumulatorRuleSelectionTests`. **3 fail on the old code**, including the case where the more specific pattern comes first and must still lose. The fourth is a guard: a later rule for the *other* phase must not shadow this phase's rule. The XSLT unit suite passes on net10.0: 1,523 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn