### PR TITLE
fix: nodes the engine builds report their string value

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Construction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Construction.cs
@@ -1046,6 +1046,7 @@ internal sealed partial class DefaultXsltExecutionContext
                         ? (_nodeStore.GetNode(docElementId) as XdmElement)?.LocalName : null;
                     var docNode = new XdmDocument
                     {
+                        StringValueResolver = _nodeStore.StringValueResolver,
                         Id = docId,
                         Document = new DocumentId(1),
                         Parent = NodeId.None,
@@ -1070,6 +1071,7 @@ internal sealed partial class DefaultXsltExecutionContext
                 var docId = _nodeStore.NextId();
                 var docNode = new XdmDocument
                 {
+                    StringValueResolver = _nodeStore.StringValueResolver,
                     Id = docId,
                     Document = new DocumentId(1),
                     Parent = NodeId.None,

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Copy.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Copy.cs
@@ -158,6 +158,7 @@ internal sealed partial class DefaultXsltExecutionContext
                                 ? (_nodeStore.GetNode(docElemId2) as XdmElement)?.LocalName : null;
                             var docNode2 = new XdmDocument
                             {
+                                StringValueResolver = _nodeStore.StringValueResolver,
                                 Id = docId2,
                                 Document = new DocumentId(1),
                                 Parent = NodeId.None,
@@ -180,6 +181,7 @@ internal sealed partial class DefaultXsltExecutionContext
                         var docId2 = _nodeStore.NextId();
                         var docNode2 = new XdmDocument
                         {
+                            StringValueResolver = _nodeStore.StringValueResolver,
                             Id = docId2,
                             Document = new DocumentId(1),
                             Parent = NodeId.None,
@@ -1112,6 +1114,7 @@ internal sealed partial class DefaultXsltExecutionContext
                     childIds.Add(CloneSubtreeDeep(c, id, copyNamespaces, forceDocument));
                 var clone = new XdmElement
                 {
+                    StringValueResolver = _nodeStore.StringValueResolver,
                     Id = id, Document = cloneDoc, Namespace = e.Namespace,
                     LocalName = e.LocalName, Prefix = e.Prefix,
                     Attributes = attrIds.Count == 0 ? XdmElement.EmptyAttributes : System.Collections.Immutable.ImmutableArray.CreateRange(attrIds),
@@ -1209,6 +1212,7 @@ internal sealed partial class DefaultXsltExecutionContext
 
         var newDoc = new XdmDocument
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = newDocId,
             Document = new DocumentId((uint)newDocId.Value),
             Parent = NodeId.None,
@@ -1269,6 +1273,7 @@ internal sealed partial class DefaultXsltExecutionContext
                 }
                 var newElem = new XdmElement
                 {
+                    StringValueResolver = _nodeStore.StringValueResolver,
                     Id = newId,
                     Document = elem.Document,
                     Parent = parentId,

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.NodeIO.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.NodeIO.cs
@@ -205,6 +205,7 @@ internal sealed partial class DefaultXsltExecutionContext
 
         var elem = new XdmElement
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = elemId,
             Document = docId,
             Parent = parentId,
@@ -353,6 +354,7 @@ internal sealed partial class DefaultXsltExecutionContext
 
                     var newDoc = new XdmDocument
                     {
+                        StringValueResolver = _nodeStore.StringValueResolver,
                         Id = xdmDoc.Id,
                         Document = xdmDoc.Document,
                         Parent = xdmDoc.Parent,
@@ -467,6 +469,7 @@ internal sealed partial class DefaultXsltExecutionContext
 
         var elem = new Xdm.Nodes.XdmElement
         {
+            StringValueResolver = _nodeStore!.StringValueResolver,
             Id = startId,
             Document = DocumentId.None,
             Parent = NodeId.None,

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
@@ -1725,6 +1725,7 @@ internal sealed partial class DefaultXsltExecutionContext
                 var syntheticDocId = new NodeId(999_999);
                 var syntheticDoc = new XdmDocument
                 {
+                    StringValueResolver = streamNodeStore.StringValueResolver,
                     Id = syntheticDocId,
                     Document = new DocumentId(0),
                     Children = [],

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Streaming.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Streaming.cs
@@ -790,6 +790,7 @@ internal sealed partial class DefaultXsltExecutionContext
                 NodeId? docElemId = root is XdmElement ? rootId : (NodeId?)null;
                 doc = new XdmDocument
                 {
+                    StringValueResolver = _nodeStore.StringValueResolver,
                     Id = tempDocId,
                     Document = new DocumentId(1),
                     Parent = NodeId.None,

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Variables.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Variables.cs
@@ -668,6 +668,7 @@ internal sealed partial class DefaultXsltExecutionContext
                                 ? (_nodeStore.GetNode(docElementId) as XdmElement)?.LocalName : null;
                             var docNode = new XdmDocument
                             {
+                                StringValueResolver = _nodeStore.StringValueResolver,
                                 Id = docId,
                                 Document = new DocumentId(1),
                                 Parent = NodeId.None,
@@ -768,6 +769,7 @@ internal sealed partial class DefaultXsltExecutionContext
                                 ? (_nodeStore.GetNode(flipDocElementId) as XdmElement)?.LocalName : null;
                             var flipDocNode = new XdmDocument
                             {
+                                StringValueResolver = _nodeStore.StringValueResolver,
                                 Id = docId,
                                 Document = new DocumentId(1),
                                 Parent = NodeId.None,

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -1614,6 +1614,7 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
             ? (_nodeStore.GetNode(docElemId) as XdmElement)?.LocalName : null;
         var docNode = new XdmDocument
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = docId,
             Document = new DocumentId(1),
             Parent = NodeId.None,
@@ -2095,6 +2096,7 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
 
         var flipDoc = new XdmDocument
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = docId,
             Document = new DocumentId(1),
             Parent = NodeId.None,

--- a/src/PhoenixmlDb.Xslt/Engine/JsonToXmlConverter.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/JsonToXmlConverter.cs
@@ -36,6 +36,7 @@ internal static class JsonToXmlConverter
 
         var doc = new XdmDocument
         {
+            StringValueResolver = store.StringValueResolver,
             Id = docId,
             Document = default,
             Children = new[] { rootElem.Id },
@@ -91,6 +92,7 @@ internal static class JsonToXmlConverter
 
         var elem = new XdmElement
         {
+            StringValueResolver = store.StringValueResolver,
             Id = elemId,
             Document = default,
             Namespace = FnNs,
@@ -122,6 +124,7 @@ internal static class JsonToXmlConverter
 
         var elem = new XdmElement
         {
+            StringValueResolver = store.StringValueResolver,
             Id = elemId,
             Document = default,
             Namespace = FnNs,
@@ -177,6 +180,7 @@ internal static class JsonToXmlConverter
 
         var elem = new XdmElement
         {
+            StringValueResolver = store.StringValueResolver,
             Id = elemId,
             Document = default,
             Namespace = FnNs,
@@ -201,6 +205,7 @@ internal static class JsonToXmlConverter
 
         var elem = new XdmElement
         {
+            StringValueResolver = store.StringValueResolver,
             Id = elemId,
             Document = default,
             Namespace = FnNs,

--- a/src/PhoenixmlDb.Xslt/Engine/SnapshotHelper.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/SnapshotHelper.cs
@@ -143,6 +143,7 @@ internal static class SnapshotHelper
                 nodeMapping?.TryAdd(ancestorDoc.Id, newDocId);
                 var newDoc = new XdmDocument
                 {
+                    StringValueResolver = store.StringValueResolver,
                     Id = newDocId,
                     Document = docId,
                     Parent = NodeId.None,
@@ -183,6 +184,7 @@ internal static class SnapshotHelper
 
                 var newElem = new XdmElement
                 {
+                    StringValueResolver = store.StringValueResolver,
                     Id = newElemId,
                     Document = docId,
                     Parent = previousCopyId,
@@ -223,6 +225,7 @@ internal static class SnapshotHelper
         {
             var newDoc = new XdmDocument
             {
+                StringValueResolver = store.StringValueResolver,
                 Id = doc.Id,
                 Document = doc.Document,
                 Parent = doc.Parent,
@@ -237,6 +240,7 @@ internal static class SnapshotHelper
         {
             var newElem = new XdmElement
             {
+                StringValueResolver = store.StringValueResolver,
                 Id = elem.Id,
                 Document = elem.Document,
                 Parent = elem.Parent,
@@ -300,6 +304,7 @@ internal static class SnapshotHelper
 
                 var newDoc = new XdmDocument
                 {
+                    StringValueResolver = store.StringValueResolver,
                     Id = newId,
                     Document = docId,
                     Parent = NodeId.None,
@@ -355,6 +360,7 @@ internal static class SnapshotHelper
 
                 var newElem = new XdmElement
                 {
+                    StringValueResolver = store.StringValueResolver,
                     Id = newId,
                     Document = docId,
                     Parent = parentId,

--- a/src/PhoenixmlDb.Xslt/Engine/StreamingSubtreeMaterializer.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StreamingSubtreeMaterializer.cs
@@ -207,6 +207,7 @@ internal static class StreamingSubtreeMaterializer
     {
         var elem = new XdmElement
         {
+            StringValueResolver = store.StringValueResolver,
             Id = frame.Id,
             Document = frame.DocumentId,
             Namespace = frame.Namespace,

--- a/src/PhoenixmlDb.Xslt/Engine/StreamingXmlProcessor.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StreamingXmlProcessor.cs
@@ -1438,6 +1438,7 @@ internal sealed class StreamingXmlProcessor
         var docNodeId = _nodeStore.NextId();
         _nodeStore.Register(new XdmDocument
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = docNodeId,
             Document = documentId,
             Children = XdmDocument.EmptyChildren,
@@ -1878,6 +1879,7 @@ internal sealed class StreamingXmlProcessor
         }
         var elem = new XdmElement
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = elemId,
             Document = documentId,
             Namespace = _nodeStore.InternNamespace(string.Empty),
@@ -2371,6 +2373,7 @@ internal sealed class StreamingXmlProcessor
 
         var elem = new XdmElement
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = elemId,
             Document = documentId,
             Namespace = _nodeStore.InternNamespace(namespaceUri ?? string.Empty),
@@ -2523,6 +2526,7 @@ internal sealed class StreamingXmlProcessor
 
         var elem = new XdmElement
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = elemId,
             Document = documentId,
             Namespace = _nodeStore.InternNamespace(frame.NamespaceUri ?? string.Empty),
@@ -2808,6 +2812,7 @@ internal sealed class StreamingXmlProcessor
         var docId = _nodeStore.NextId();
         _nodeStore.Register(new XdmDocument
         {
+            StringValueResolver = _nodeStore.StringValueResolver,
             Id = docId,
             Document = StreamingDocumentId,
             Children = XdmDocument.EmptyChildren,

--- a/src/PhoenixmlDb.Xslt/Engine/TreeConstructor.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/TreeConstructor.cs
@@ -286,6 +286,7 @@ internal sealed class TreeConstructor
         var frame = _open.Pop();
         var elem = new XdmElement
         {
+            StringValueResolver = _store.StringValueResolver,
             Id = frame.Id,
             Document = frame.DocumentId,
             Namespace = frame.Namespace,
@@ -323,6 +324,7 @@ internal sealed class TreeConstructor
         var docNodeId = _store.NextId();
         var doc = new XdmDocument
         {
+            StringValueResolver = _store.StringValueResolver,
             Id = docNodeId,
             Document = _documentId,
             Children = _roots.Count == 0 ? XdmDocument.EmptyChildren : _roots.ToImmutableArray(),

--- a/src/PhoenixmlDb.Xslt/Engine/XsltParseXmlFragmentFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltParseXmlFragmentFunction.cs
@@ -46,6 +46,7 @@ internal sealed class XsltParseXmlFragmentFunction : PhoenixmlDb.XQuery.Ast.XQue
                 var docId = _context._nodeStore.NextId();
                 var emptyDoc = new Xdm.Nodes.XdmDocument
                 {
+                    StringValueResolver = _context._nodeStore.StringValueResolver,
                     Id = docId,
                     Document = new DocumentId(1),
                     Parent = NodeId.None,

--- a/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
@@ -1284,6 +1284,7 @@ public sealed class XsltTransformEngine
         var syntheticDocId = nodeStore.NextId();
         var syntheticDoc = new XdmDocument
         {
+            StringValueResolver = nodeStore.StringValueResolver,
             Id = syntheticDocId,
             Document = new DocumentId(0),
             Children = [],
@@ -3827,6 +3828,7 @@ public sealed class XsltTransformEngine
                                     ? (context._nodeStore.GetNode(docElementId) as XdmElement)?.LocalName : null;
                                 var docNode = new XdmDocument
                                 {
+                                    StringValueResolver = context._nodeStore.StringValueResolver,
                                     Id = docId,
                                     Document = new DocumentId(1),
                                     Parent = NodeId.None,
@@ -4243,6 +4245,7 @@ public sealed class XsltTransformEngine
                     }
                     var docNode = new XdmDocument
                     {
+                        StringValueResolver = context._nodeStore.StringValueResolver,
                         Id = docId,
                         Document = new DocumentId(1),
                         Parent = NodeId.None,
@@ -4846,6 +4849,7 @@ public sealed class XsltTransformEngine
         var syntheticDocId = nodeStore.NextId();
         var syntheticDoc = new XdmDocument
         {
+            StringValueResolver = nodeStore.StringValueResolver,
             Id = syntheticDocId,
             Document = new DocumentId(0),
             Children = [],
@@ -5115,6 +5119,7 @@ public sealed class XsltTransformEngine
         var probeStore = new XdmInMemoryStore();
         var probeDoc = new XdmDocument
         {
+            StringValueResolver = probeStore.StringValueResolver,
             Id = probeStore.NextId(),
             Document = new DocumentId(0),
             Children = []
@@ -5305,6 +5310,7 @@ public sealed class XsltTransformEngine
 
         var docNode = new XdmDocument
         {
+            StringValueResolver = store.StringValueResolver,
             Id = docId,
             Document = new DocumentId(1),
             Parent = NodeId.None,
@@ -5453,6 +5459,7 @@ public sealed class XsltTransformEngine
 
                 var elem = new XdmElement
                 {
+                    StringValueResolver = store.StringValueResolver,
                     Id = elemId,
                     Document = docId,
                     Parent = parentId,

--- a/src/PhoenixmlDb.Xslt/XdmInMemoryStore.cs
+++ b/src/PhoenixmlDb.Xslt/XdmInMemoryStore.cs
@@ -53,6 +53,45 @@ public sealed class XdmInMemoryStore : INodeBuilder
     public void Register(XdmNode node) => _nodes[node.Id] = node;
     public XdmNode? GetNode(NodeId id) => _nodes.GetValueOrDefault(id);
 
+    /// <summary>
+    /// Computes an element's or document node's string value from its children in this store,
+    /// for nodes built without one. Give it to every element and document node the engine
+    /// constructs: <c>StringValueResolver = store.StringValueResolver</c>.
+    /// </summary>
+    /// <remarks>
+    /// A node's string value is its cached value, else its resolver's answer, else, silently,
+    /// the empty string. So a node built with children but no computed value read as empty,
+    /// indistinguishable from a genuinely empty one: <c>xsl:value-of</c> of an
+    /// <c>as="document-node()"</c> variable printed nothing, and so did json-to-xml's result.
+    /// Nodes that do compute their value keep it; the cached value always wins over this.
+    /// </remarks>
+    public XdmNode.XdmStringValueResolver StringValueResolver => _stringValueResolver ??= ComputeStringValue;
+
+    private XdmNode.XdmStringValueResolver? _stringValueResolver;
+
+    private string ComputeStringValue(XdmNode node)
+    {
+        var children = node switch
+        {
+            XdmElement e => e.Children,
+            XdmDocument d => d.Children,
+            _ => null,
+        };
+        if (children is not { Count: > 0 })
+            return string.Empty;
+        var sb = new System.Text.StringBuilder();
+        foreach (var id in children)
+        {
+            switch (GetNode(id))
+            {
+                case XdmText text: sb.Append(text.Value); break;
+                // An element child answers from its own cache or resolver.
+                case XdmElement child: sb.Append(child.StringValue); break;
+            }
+        }
+        return sb.ToString();
+    }
+
     // INodeBuilder explicit interface implementations (delegate to existing methods)
     NodeId INodeBuilder.AllocateId() => NextId();
     void INodeBuilder.RegisterNode(XdmNode node) => Register(node);

--- a/tests/PhoenixmlDb.Xslt.Tests/NodeStringValueTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/NodeStringValueTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Element and document nodes the engine builds must report their string value. A node's string
+/// value is its cached value, else its resolver's answer, else — silently — the empty string, so a
+/// node built with children but neither a value nor a resolver read as empty: indistinguishable
+/// from a genuinely empty node, and printed as nothing.
+/// </summary>
+/// <remarks>
+/// This test project runs with <c>PhoenixmlDb.Xdm.StrictStringValue</c> on
+/// (runtimeconfig.template.json), which makes that third case throw instead of returning "". So
+/// any construction site added without <c>StringValueResolver = store.StringValueResolver</c>
+/// fails the suite rather than printing nothing in production.
+/// </remarks>
+public sealed class NodeStringValueTests
+{
+    private static async Task<string> RunAsync(string body, string declarations = "")
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              {{declarations}}
+              <xsl:template match="/">{{body}}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc>source</doc>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("""<xsl:variable name="v" as="document-node()"><a>hello</a></xsl:variable><xsl:value-of select="$v"/>""", "hello")]
+    [InlineData("""<xsl:variable name="v" as="document-node()"><a>he<b>ll</b>o</a></xsl:variable><xsl:value-of select="$v"/>""", "hello")]
+    [InlineData("""<xsl:variable name="v" as="document-node()"><xsl:copy-of select="/"/></xsl:variable><xsl:value-of select="$v"/>""", "source")]
+    [InlineData("""<xsl:value-of select="json-to-xml('{&quot;a&quot;:&quot;x&quot;}')"/>""", "x")]
+    [InlineData("""<xsl:value-of select="json-to-xml('[&quot;p&quot;,&quot;q&quot;]')"/>""", "pq")]
+    public async Task AConstructedNode_ReportsItsStringValue(string body, string expected)
+        => (await RunAsync(body)).Should().Be(expected);
+
+    [Fact]
+    public async Task ATypedGlobalDocument_ReportsItsStringValue()
+        => (await RunAsync("""<xsl:value-of select="$g"/>""",
+                """<xsl:variable name="g" as="document-node()"><r>glo<s>bal</s></r></xsl:variable>"""))
+            .Should().Be("global");
+}

--- a/tests/PhoenixmlDb.Xslt.Tests/runtimeconfig.template.json
+++ b/tests/PhoenixmlDb.Xslt.Tests/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "PhoenixmlDb.Xdm.StrictStringValue": true
+  }
+}


### PR DESCRIPTION
From the #53 audit ("a provisional value reads like a settled one").

### The defect
In Core, a node's string value is its cached value, then its `StringValueResolver`'s answer, then **silently `""`**. The XSLT engine constructs element or document nodes in 45 places, and about a third of them set neither a value nor a resolver. A node built *with children* therefore read as empty, and nothing flagged it:

| stylesheet | was | now |
|---|---|---|
| `<xsl:variable name="v" as="document-node()"><a>hello</a></xsl:variable><xsl:value-of select="$v"/>` | *(nothing)* | `hello` |
| `<xsl:value-of select="json-to-xml('{"a":"x"}')"/>` | *(nothing)* | `x` |

### The fix
`XdmInMemoryStore.StringValueResolver` computes a node's value from its children in the store. Every construction site now passes it: 43 sites. The streaming element pool and its motionless ancestors never hold children, so they're left alone. Where a value is already computed, it still wins, so nothing that was right changes.

**Guard:** the unit-test project now runs with `PhoenixmlDb.Xdm.StrictStringValue` on. Under it, a node with neither a value nor a resolver *throws* instead of reading `""`. A construction site added later without the resolver will fail the suite rather than print nothing in production.

### Evidence, stated plainly
- **W3C: no case changes.** A same-checkout A/B against the pinned XQuery 1.7.0, without strict mode, gives 10,161 on both sides. Under strict mode, the sweep finds 25 cases on main that read an unresolved value, and all 25 are resolved here, but none of them decided an assertion. The suites just don't exercise the broken shapes.
- 6 new tests in `NodeStringValueTests`, of which **5 fail on main**. The typed-global case already worked, so it's a guard.
- All 1,529 unit tests pass under strict mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn