### PR TITLE
fix: a global variable is evaluated once

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
@@ -3605,6 +3605,19 @@ public sealed class XsltTransformEngine
         {
             if (deferredAbstractGlobals.ContainsKey(global.Name))
                 continue; // bound above as a deferred XTDE3052 value
+            // A global leaves the pending map when its evaluation STARTS, not when it ends.
+            // Two defects came from treating membership as "not yet bound":
+            //   - a global already initialized on demand (GetVariable → InitializePendingGlobalAsync,
+            //     for a dependency the static analysis missed) was evaluated AGAIN here and
+            //     rebound — a second node identity, side effects twice: $a is $b was false for
+            //     <xsl:variable name="a" select="f:get()"/> where f:get returns $b;
+            //   - while evaluated here it still read as pending, so a reference to it re-entered
+            //     initialization instead of reaching the XTDE0640 circularity check.
+            // One whose on-demand evaluation failed (not bound) is evaluated again, so its own
+            // error surfaces rather than "not defined".
+            var wasPending = context._pendingGlobals.Remove(global.Name);
+            if (!wasPending && context.GlobalVariables.ContainsKey(global.Name))
+                continue;
             // Push per-element version for backwards-compatible mode propagation
             if (global.Version != null)
                 context.PushVersion(global.Version);
@@ -3985,8 +3998,6 @@ public sealed class XsltTransformEngine
                 if (global.Version != null)
                     context.PopVersion();
             }
-            // Remove from pending now that it's been initialized
-            context._pendingGlobals?.Remove(global.Name);
         }
         // Clear pending map — all globals should be initialized now
         context._pendingGlobals = null;

--- a/tests/PhoenixmlDb.Xslt.Tests/GlobalEvaluatedOnceTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/GlobalEvaluatedOnceTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A global variable is evaluated once. Globals are initialized in dependency order, and a
+/// dependency the static analysis misses is initialized on demand when first read. The ordered
+/// pass then evaluated that global a second time and rebound it: a node it built got a second
+/// identity, and anything the evaluation did happened twice.
+/// </summary>
+public sealed class GlobalEvaluatedOnceTests
+{
+    // f:get reads $b from inside a local variable, which the dependency analysis does not follow,
+    // so $a (evaluated first) initializes $b on demand.
+    private const string Functions = """
+        <xsl:function name="f:get"><xsl:variable name="t" select="$b"/><xsl:sequence select="$t"/></xsl:function>
+        """;
+
+    private static async Task<(string Output, List<string> Messages)> RunAsync(string declarations, string body)
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:f="urn:f" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              {{declarations}}
+              <xsl:template match="/">{{body}}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var messages = new List<string>();
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        t.MessageListener = (text, _) => messages.Add(text);
+        return ((await t.TransformAsync("<doc/>")).Trim(), messages);
+    }
+
+    [Fact]
+    public async Task AGlobalInitializedOnDemand_KeepsItsNodeIdentity()
+    {
+        var (output, _) = await RunAsync(Functions + """
+            <xsl:variable name="a" select="f:get()"/>
+            <xsl:variable name="b" select="parse-xml('&lt;x/&gt;')"/>
+            """, """<xsl:value-of select="$a is $b"/>""");
+        output.Should().Be("true");
+    }
+
+    [Fact]
+    public async Task AGlobalInitializedOnDemand_IsEvaluatedOnce()
+    {
+        var (_, messages) = await RunAsync(Functions + """
+            <xsl:variable name="a" select="f:get()"/>
+            <xsl:variable name="b"><xsl:message>evaluating b</xsl:message><x/></xsl:variable>
+            """, """<xsl:value-of select="count(($a, $b))"/>""");
+        messages.Should().ContainSingle(m => m.Contains("evaluating b"));
+    }
+}


### PR DESCRIPTION
From the #53 audit ("a provisional value reads like a settled one").

### The defect
Globals initialize in dependency order. A global that the static analysis misses is initialized **on demand** when first read. The ordered pass took membership of the pending map to mean "not yet bound", but the on-demand path removes the entry when it *starts*. So the ordered pass evaluated that global a second time and rebound it. Any node it built got a second identity, and anything the evaluation did happened twice:

```xml
<xsl:function name="f:get"><xsl:variable name="t" select="$b"/><xsl:sequence select="$t"/></xsl:function>
<xsl:variable name="a" select="f:get()"/>
<xsl:variable name="b" select="parse-xml('<x/>')"/>
$a is $b    <!-- was false; an xsl:message in $b fired twice -->
```

### The fix
The ordered pass now removes a global from pending when its evaluation starts, as the on-demand path already does, and it skips a global that's already bound. That also closes a second hole: while being evaluated in order, a global still read as pending, so a reference to it re-entered initialization instead of reaching the circularity check. A global whose on-demand evaluation *failed* is still evaluated, so its own error surfaces rather than "not defined".

### Evidence
- **W3C: no case changes.** The comparison was run on the same checkout against the pinned XQuery 1.7.0. The one difference, call-template-1003, is the known flicker.
- 2 new tests in `GlobalEvaluatedOnceTests`, **both failing on main**. The XSLT unit suite passes on net10.0: 1,525 passed, 0 failed.

**Found while writing tests, and deliberately not in this PR:** an indirect global cycle reports `XPST0008: Variable $c not defined` where XTDE0640 is due. That's identical on main, so it's pre-existing, and I've handed it to the register separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn