### PR TITLE
fix: text in an xsl:variable is written once, in document order

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
@@ -2164,10 +2164,13 @@ internal sealed partial class DefaultXsltExecutionContext
             _collectedAttributesStack.Clear();
             _temporaryOutputDepth++;
             _functionBodyDepth++;
+            var savedFunctionBodyAccumulator = _functionBodyAccumulator;
+            _functionBodyAccumulator = _sequenceAccumulator;
             try
             { await func.Body.ExecuteAsync(this).ConfigureAwait(false); }
             finally
             {
+                _functionBodyAccumulator = savedFunctionBodyAccumulator;
                 _functionBodyDepth--;
                 _temporaryOutputDepth--;
                 // Restore namespace scopes

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
@@ -251,7 +251,7 @@ internal sealed partial class DefaultXsltExecutionContext
         // comment/PI content), also write escaped text to _output so that
         // text and LRE elements preserve their source order when the function
         // result is assembled from both _sequenceAccumulator and _output.
-        if (_functionBodyDepth == 0 || _textContentDepth != 0)
+        if (!InFunctionBodyProper || _textContentDepth != 0)
             return false;
         EmitText(value);
         // This item now OWNS the text just written. Without this the weave emits the
@@ -270,7 +270,7 @@ internal sealed partial class DefaultXsltExecutionContext
         // If sequence accumulation is active, add as a TextNodeItem marker
         // to distinguish text nodes from atomic strings (for §5.7.2 processing)
         var emittedToOutput = false;
-        if (_sequenceAccumulator != null)
+        if (_sequenceAccumulator != null && !InTreeBody)
         {
             emittedToOutput = AccumulateTextItem(value);
         }

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
@@ -622,6 +622,36 @@ internal sealed partial class DefaultXsltExecutionContext
     // Track when inside function body so xsl:value-of routes to sequence accumulator
     private int _functionBodyDepth;
 
+    // The accumulator the innermost executing stylesheet function collects its result into.
+    // "Directly in a function body" is _sequenceAccumulator being THIS list — not
+    // _functionBodyDepth > 0, which is also true inside an xsl:variable nested in the body. See
+    // InFunctionBodyProper.
+    private List<object?>? _functionBodyAccumulator;
+
+    /// <summary>
+    /// True when the sequence being built is the executing function's own result — the only
+    /// place text is written to BOTH the accumulator and <c>_output</c>, because only the
+    /// function-result assembly knows to treat accumulated text as a duplicate of the output.
+    /// </summary>
+    /// <remarks>
+    /// This was <c>_functionBodyDepth &gt; 0</c>, which also holds inside an xsl:variable in the
+    /// body. That variable's accumulator got the text as an item AND its buffer got the text, and
+    /// its drain emitted both: <c>string($v)</c> of
+    /// <c>&lt;xsl:variable name="v"&gt;&lt;xsl:text&gt;x&lt;/xsl:text&gt;&lt;/xsl:variable&gt;</c>
+    /// inside a function was <c>xx</c>. It has been wrong at least since before 1.7.0.
+    /// </remarks>
+    // The accumulator an untyped (temporary-tree) xsl:variable body is building behind. It only
+    // catches typed results from nested instructions and is drained AFTER the body's text, so text
+    // written to it lands out of order: <xsl:variable>a<b>c</b><xsl:text>d</xsl:text>e</xsl:variable>
+    // read "aced", and copying it gave a<b>c</b>ed. Text in such a body goes to the buffer.
+    private List<object?>? _treeBodyAccumulator;
+
+    private bool InTreeBody =>
+        _sequenceAccumulator != null && ReferenceEquals(_sequenceAccumulator, _treeBodyAccumulator);
+
+    private bool InFunctionBodyProper =>
+        _sequenceAccumulator != null && ReferenceEquals(_sequenceAccumulator, _functionBodyAccumulator);
+
     // Track when inside xsl:where-populated so XTDE0410 is suppressed during trial evaluation
     private int _wherePopulatedDepth;
 

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Variables.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Variables.cs
@@ -884,6 +884,13 @@ internal sealed partial class DefaultXsltExecutionContext
                 // body inside fp:run-transforms function).
                 var savedAccumulatorVar = _sequenceAccumulator;
                 _sequenceAccumulator = new List<object?>();
+                // This body builds a TREE. Its accumulator only catches typed results from nested
+                // instructions (drained after the text below); text belongs in the buffer, in
+                // document order. See _treeBodyAccumulator.
+                var savedTreeBodyAccumulator = _treeBodyAccumulator;
+                _treeBodyAccumulator = _sequenceAccumulator;
+                var savedCollectTextVar = _collectTextAsSequenceItems;
+                _collectTextAsSequenceItems = false;
                 _documentNodeDepth++;
                 _temporaryOutputDepth++;
                 // SP-C slice 3: install a fresh TreeConstructor for the duration of this
@@ -945,6 +952,8 @@ internal sealed partial class DefaultXsltExecutionContext
                     }
                     capturedAccumulator = _sequenceAccumulator;
                     _sequenceAccumulator = savedAccumulatorVar;
+                    _treeBodyAccumulator = savedTreeBodyAccumulator;
+                    _collectTextAsSequenceItems = savedCollectTextVar;
                     _temporaryOutputDepth--;
                     _documentNodeDepth--;
                     _textContentDepth = savedTextDepth;

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -2393,7 +2393,7 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
         // This ensures count(fn()) is correct when fn() uses xsl:value-of.
         // Only in function body context — not in variable/param body where text
         // needs to be serialized as part of the result tree.
-        if (_functionBodyDepth > 0 && _sequenceAccumulator != null
+        if (InFunctionBodyProper
             && _textContentDepth == 0 && _serializingElementDepth == 0
             && !instruction.DisableOutputEscaping)
         {

--- a/tests/PhoenixmlDb.Xslt.Tests/FunctionLocalVariableTextTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/FunctionLocalVariableTextTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Text written into an xsl:variable belongs to that variable once, and in document order.
+/// Directly in a function body, text is written to both the result accumulator and the output
+/// buffer, because the function-result assembly treats the accumulated copy as a duplicate. That
+/// rule keyed on "inside a function at any depth", so it also fired inside a local variable,
+/// whose drain emitted both copies: <c>string($v)</c> came back <c>xx</c>.
+/// </summary>
+public sealed class FunctionLocalVariableTextTests
+{
+    private const string Functions = """
+        <xsl:function name="f:typed" as="xs:string"><xsl:variable name="v"><xsl:value-of select="'x'"/></xsl:variable><xsl:sequence select="string($v)"/></xsl:function>
+        <xsl:function name="f:untyped"><xsl:variable name="v"><xsl:value-of select="'x'"/></xsl:variable><xsl:sequence select="string($v)"/></xsl:function>
+        <xsl:function name="f:text" as="xs:string"><xsl:variable name="v"><xsl:text>x</xsl:text></xsl:variable><xsl:sequence select="string($v)"/></xsl:function>
+        <xsl:function name="f:mixed"><xsl:param name="n"/><xsl:variable name="v">a<b>c</b><xsl:value-of select="$n"/></xsl:variable><xsl:sequence select="string($v)"/></xsl:function>
+        """;
+
+    private static async Task<string> RunAsync(string body)
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:f="urn:f" exclude-result-prefixes="#all">
+              <xsl:output method="xml" omit-xml-declaration="yes"/>
+              {{Functions}}
+              <xsl:template match="/">{{body}}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("f:typed()")]
+    [InlineData("f:untyped()")]
+    [InlineData("f:text()")]
+    public async Task ALocalVariablesText_IsNotDoubled_AtEitherDepth(string call)
+        => (await RunAsync($"""[<xsl:value-of select="{call}"/>]<out><xsl:value-of select="{call}"/></out>"""))
+            .Should().Be("[x]<out>x</out>", "the answer was xx at the top level, and for two of the three inside <out> too");
+
+    [Fact]
+    public async Task MixedContent_InALocalVariable_IsNotDoubled()
+        => (await RunAsync("""<xsl:value-of select="f:mixed('d')"/>""")).Should().Be("acd");
+
+    /// <summary>
+    /// Outside any function too: an untyped variable builds a tree, and its accumulator only
+    /// catches typed results from nested instructions, drained after the text. xsl:text went to
+    /// that accumulator, so it moved to the end.
+    /// </summary>
+    [Theory]
+    [InlineData("""<xsl:value-of select="string($v)"/>""", "acde")]
+    [InlineData("""<xsl:copy-of select="$v"/>""", "a<b>c</b>de")]
+    public async Task TextInAnUntypedVariable_KeepsDocumentOrder(string use, string expected)
+        => (await RunAsync($"""<xsl:variable name="v">a<b>c</b><xsl:text>d</xsl:text><xsl:value-of select="'e'"/></xsl:variable>{use}"""))
+            .Should().Be(expected);
+
+    [Fact]
+    public async Task TextDirectlyInAFunctionBody_StillOrdersWithElements()
+    {
+        // The both-channels rule exists for this: text and an element returned together keep order.
+        var ss = """
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:f="urn:f" exclude-result-prefixes="#all">
+              <xsl:output method="xml" omit-xml-declaration="yes"/>
+              <xsl:function name="f:te"><xsl:text>t</xsl:text><e/><xsl:value-of select="'v'"/></xsl:function>
+              <xsl:template match="/"><out><xsl:copy-of select="f:te()"/></out></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        (await t.TransformAsync("<doc/>")).Trim().Should().Be("<out>t<e/>v</out>");
+    }
+}


### PR DESCRIPTION
From the #53 audit. Two ways text in an untyped `xsl:variable` went wrong, and both come from treating "an accumulator exists" as if it meant "we are building a sequence".

### 1. Doubled inside functions
Directly in a function body, text is written to *both* the result accumulator and the output buffer, because the function-result assembly treats the accumulated copy as a duplicate. The rule keyed on `_functionBodyDepth > 0`, which is true anywhere beneath a function, **including inside a local variable**. That variable's drain then emitted both copies:

| function body | at top level | inside `<out>` |
|---|---|---|
| `as="xs:string"`, `<xsl:variable><xsl:value-of select="'x'"/></xsl:variable>`, then `string($v)` | `xx` → **`x`** | `x` |
| no `as`, same body | `xx` → **`x`** | `xx` → **`x`** |
| `as="xs:string"`, `<xsl:text>x</xsl:text>` | `xx` → **`x`** | `xx` → **`x`** |

The rule now keys on the accumulator being the function's *own* (`InFunctionBodyProper`).

### 2. Reordered everywhere
An untyped variable builds a tree. Its accumulator only catches typed results from nested instructions, and it's drained **after** the body's text. `xsl:text` went into that accumulator, so it moved to the end:

```xml
<xsl:variable name="v">a<b>c</b><xsl:text>d</xsl:text><xsl:value-of select="'e'"/></xsl:variable>
string($v)      was "aced"          now "acde"
copy-of $v      was a<b>c</b>ed     now a<b>c</b>de
```

Text in such a body now goes to the buffer in document order, and the function body's text-as-items mode no longer leaks into it.

Both bugs predate 1.7.0: the first reproduces identically on the commit before #20.

### Evidence
- **W3C**, same checkout against the pinned XQuery 1.7.0: **10,161 → 10,164** (axes-046, evaluate-004, bug-2601), with **zero per-set losses**.
- 7 new tests in `FunctionLocalVariableTextTests`, of which **6 fail on main**. The seventh guards the case the both-channels rule exists for: text and an element returned together from a function keep their order.
- The unit suite passes on net10.0 under strict string values: 1,536 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn