### PR TITLE
fix: a streamed match="/" template aggregates over the whole document

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/StreamWatcher.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StreamWatcher.cs
@@ -508,7 +508,9 @@ internal sealed class StreamWatcher
         return Aggregation switch
         {
             WatcherAggregation.Count => _count,
-            WatcherAggregation.Sum => _count > 0 ? _sum : null,
+            // fn:sum(()) is xs:integer 0. The two-argument form's default needs the live
+            // scope, so it stays null here and the caller evaluates SumDefaultExpression.
+            WatcherAggregation.Sum => _count > 0 ? _sum : SumDefaultExpression == null ? 0L : null,
             WatcherAggregation.Max => _max.HasValue ? _max.Value : null,
             WatcherAggregation.Min => _min.HasValue ? _min.Value : null,
             WatcherAggregation.Avg => _count > 0 ? _sum / _count : null,

--- a/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
@@ -5020,15 +5020,30 @@ public sealed class XsltTransformEngine
                     context._activeStreamingProcessor = null;
                     context._activeStreamingReader = null;
 
-                    if (docSubscriptions == null)
+                    if (docSubscriptions == null && docWatchers != null)
                     {
-                        // Literal-only body (e.g. match="/" producing <ROOTRAN/>):
-                        // execute once; the forward pass below merely drains the reader
-                        // in dispatch-only mode without firing built-in templates.
+                        // Consuming aggregates (sum(//x), count(//*), …): the forward pass
+                        // FIRST, so the watchers have seen the document, THEN the body, which
+                        // reads their results — the order the xsl:source-document path uses.
+                        // This was handled as a literal-only body and run BEFORE the pass,
+                        // against watchers that had seen nothing: under a streamable mode,
+                        // <xsl:value-of select="count(//PRICE)"/> in match="/" gave 0 and
+                        // sum(//PRICE) gave nothing, whatever the input held.
+                        await docProcessor.ProcessAsync(inputReader, options.CancellationToken).ConfigureAwait(false);
                         await docNodeTemplate.Body.ExecuteAsync(context).ConfigureAwait(false);
                     }
+                    else
+                    {
+                        if (docSubscriptions == null)
+                        {
+                            // Literal-only body (e.g. match="/" producing <ROOTRAN/>):
+                            // execute once; the forward pass below merely drains the reader
+                            // in dispatch-only mode without firing built-in templates.
+                            await docNodeTemplate.Body.ExecuteAsync(context).ConfigureAwait(false);
+                        }
 
-                    await docProcessor.ProcessAsync(inputReader, options.CancellationToken).ConfigureAwait(false);
+                        await docProcessor.ProcessAsync(inputReader, options.CancellationToken).ConfigureAwait(false);
+                    }
                 }
                 else
                 {

--- a/tests/PhoenixmlDb.Xslt.Tests/StreamingDocumentAggregateTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/StreamingDocumentAggregateTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Under a streamable mode, a <c>match="/"</c> template whose body aggregates over the stream —
+/// <c>count(//x)</c>, <c>sum(//x)</c> — answers from the whole document. Its body was treated
+/// as literal-only and run before the streaming pass, against watchers that had seen nothing:
+/// <c>count(//PRICE)</c> was 0 and <c>sum(//PRICE)</c> empty, whatever the input held. The
+/// W3C streaming sets did not notice because they aggregate inside xsl:source-document, a
+/// different entry path; this is the plain one — the CLI streams a file this way by default.
+/// </summary>
+public sealed class StreamingDocumentAggregateTests
+{
+    private static async Task<string> RunAsync(string select, string source, bool streamed)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="text"/>
+              <xsl:mode streamable="yes"/>
+              <xsl:template match="/"><xsl:value-of select="{select}"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        var result = streamed
+            ? await t.TransformAsync(new StringReader(source))
+            : await t.TransformAsync(source);
+        return result.Trim();
+    }
+
+    private const string Prices = "<doc><ITEM><PRICE>2</PRICE></ITEM><PRICE>3</PRICE></doc>";
+    private const string NoPrices = "<doc><ITEM/></doc>";
+
+    [Theory]
+    [InlineData("count(//PRICE)", Prices, "2")]
+    [InlineData("sum(//PRICE)", Prices, "5")]
+    [InlineData("count(//*)", Prices, "4")]
+    [InlineData("max(//PRICE)", Prices, "3")]
+    [InlineData("sum(/doc/PRICE)", Prices, "3")]
+    // fn:sum(()) is 0, not the empty sequence; the two-argument form keeps its default.
+    [InlineData("sum(//PRICE)", NoPrices, "0")]
+    [InlineData("sum(//PRICE, 7)", NoPrices, "7")]
+    [InlineData("count(//PRICE)", NoPrices, "0")]
+    public async Task ADocumentTemplateAggregate_SeesTheWholeStream(string select, string source, string expected)
+    {
+        (await RunAsync(select, source, streamed: true)).Should().Be(expected);
+        (await RunAsync(select, source, streamed: false)).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Found while checking the #53 audit's streaming `sum()` finding. It turned out to be much worse than the audit's empty-input case.

### The defect
Under a streamable mode, the document-node template's body was treated as **literal-only** whenever it had no `for-each` subscriptions, and it was run **before** the streaming pass. A body that aggregates over the stream isn't literal-only: its consuming watchers hadn't seen anything yet.

```xml
<xsl:mode streamable="yes"/>
<xsl:template match="/"><xsl:value-of select="count(//PRICE)"/></xsl:template>
```

| select, over `<doc><ITEM><PRICE>2</PRICE></ITEM><PRICE>3</PRICE></doc>` | was | now (= non-streamed) |
|---|---|---|
| `count(//PRICE)` | `0` | `2` |
| `sum(//PRICE)` | *(nothing)* | `5` |
| `count(//*)` | `0` | `4` |
| `sum(//PRICE)` over no PRICE | *(nothing)* | `0` |

The W3C streaming sets aggregate inside `xsl:source-document`, a different entry path that already drains first, which is why they didn't catch it. This is the plain path, and **the CLI streams a file this way by default** when the stylesheet declares a streamable mode. `--no-stream` gave the same wrong answers.

### The fix
- When the body has consuming watchers and no subscriptions, the streaming pass now runs **first** and the body **after**. That's the order the `xsl:source-document` path uses.
- An empty single-argument `sum` watcher now reports `0` (`fn:sum(())` is `xs:integer` 0). Its own doc comment said so while the code returned null. The two-argument form still evaluates its default at resolve time.

### Evidence
- **W3C**, same checkout against the pinned XQuery 1.7.0: **function-5015a** passes (a streamable mode on the principal input), with zero real losses. The call-template-1002 loss is the known flicker.
- 8 new test cases in `StreamingDocumentAggregateTests`, each run both **streamed** (`TransformAsync(TextReader)`, which is the CLI's call) and from a string. **6 fail on main**; the other two are empty-input cases whose right answers happen to equal the broken ones.
- The unit suite passes on net10.0 under strict string values: 1,539 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn