### PR TITLE
fix: memo keys that compare equal hash equal

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/FunctionMemoKey.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/FunctionMemoKey.cs
@@ -99,14 +99,30 @@ internal sealed class FunctionMemoKey : IEquatable<FunctionMemoKey>
         }
     }
 
+    /// <summary>
+    /// Hashes a value as the sequence it is, so every representation <see cref="ValueEquals"/>
+    /// treats as equal hashes alike: null and an empty array are both (), and a single item and
+    /// a one-element array are both that item. Hashing the representation instead let equal keys
+    /// land in different buckets, a cache miss that hands new-each-time="no" a fresh node.
+    /// </summary>
     private static int ValueHash(object? value)
     {
-        if (value is not object?[] items)
-            return ItemHash(value);
         var hash = new HashCode();
-        hash.Add(items.Length);
-        foreach (var item in items)
-            hash.Add(ItemHash(item));
+        switch (value)
+        {
+            case null:
+                hash.Add(0);
+                break;
+            case object?[] items:
+                hash.Add(items.Length);
+                foreach (var item in items)
+                    hash.Add(ItemHash(item));
+                break;
+            default:
+                hash.Add(1);
+                hash.Add(ItemHash(value));
+                break;
+        }
         return hash.ToHashCode();
     }
 

--- a/tests/PhoenixmlDb.Xslt.Tests/FunctionMemoKeyTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/FunctionMemoKeyTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using PhoenixmlDb.Core;
+using PhoenixmlDb.Xslt.Ast;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Keys that compare equal hash equal. The empty sequence arrives as null or as an empty array,
+/// and a single item as itself or as a one-element array; equality normalized both, the hash did
+/// not, so an equal key could land in another bucket and miss the memo.
+/// </summary>
+public sealed class FunctionMemoKeyTests
+{
+    private static readonly XsltFunction Function = new()
+    {
+        Name = new QName(NamespaceId.None, "f"),
+        Parameters = [],
+        Body = new XsltSequenceConstructor { Instructions = [] },
+    };
+
+    private static FunctionMemoKey Key(params object?[] arguments) => new(Function, arguments);
+
+    [Theory]
+    [MemberData(nameof(EqualRepresentations))]
+    public void EqualKeys_HashEqual(object? a, object? b)
+    {
+        var (ka, kb) = (Key(a), Key(b));
+        ka.Should().Be(kb);
+        ka.GetHashCode().Should().Be(kb.GetHashCode());
+    }
+
+    public static TheoryData<object?, object?> EqualRepresentations => new()
+    {
+        { null, Array.Empty<object?>() },
+        { 1L, new object?[] { 1L } },
+        { "x", new object?[] { "x" } },
+    };
+
+    [Fact]
+    public void DifferentSequences_AreDifferentKeys()
+        => Key(new object?[] { 1L, 2L }).Should().NotBe(Key(new object?[] { 2L, 1L }));
+}


### PR DESCRIPTION
Follow-up to #21, found by the #53 audit.

`FunctionMemoKey` compares arguments as **sequences**: `null` and an empty array are both `()`, and a single item and a one-element array are both that item. But it hashed the **representation**, so two keys it considers equal could land in different buckets. A missed lookup reruns the function. For `new-each-time="no"`, that means a fresh node where the spec requires the same one.

`ValueHash` now hashes the normalized sequence.

### Evidence
- 4 new tests in `FunctionMemoKeyTests`. **3 fail on main**: the null vs `[]`, `1` vs `[1]`, and `"x"` vs `["x"]` pairs all compare equal but hashed differently. The fourth is a guard that different sequences are still different keys.
- The W3C decl chunk is unchanged, and the memoization cases (function-1025..1030) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn