### PR TITLE
fix: a prefixed variable whose value is () is found

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.ControlFlow.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.ControlFlow.cs
@@ -358,12 +358,8 @@ internal sealed partial class DefaultXsltExecutionContext
         // Fallback: prefix-based matching for unresolved namespaces
         if (name.Prefix != null)
         {
-            var fallback = FindVariableByPrefixFallback(name);
-            if (fallback != null)
-            {
-                value = fallback;
+            if (TryFindVariableByPrefixFallback(name, out value))
                 return true;
-            }
         }
 
         value = null;

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -1034,8 +1034,7 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
         // because it doesn't have XSLT namespace context. Try matching by prefix+localname or EQName.
         if (name.Prefix != null || name.ExpandedNamespace != null)
         {
-            var result = FindVariableByPrefixFallback(name);
-            if (result != null)
+            if (TryFindVariableByPrefixFallback(name, out var result))
                 return result;
         }
 
@@ -1048,7 +1047,13 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
     /// and prefix, handling the case where XPath-parsed QNames have unresolved namespaces.
     /// Also handles the case where different prefixes map to the same namespace.
     /// </summary>
-    private object? FindVariableByPrefixFallback(QName name)
+    /// <remarks>
+    /// Reports FOUND separately from the value. It returned the value, null when nothing
+    /// matched, and null is also the empty sequence, so a variable whose value is () read as
+    /// missing: <c>map{'k': $p:x}</c> with <c>$p:x := ()</c> failed with "XPST0008: Variable
+    /// $p:x not bound", while a non-empty $p:x worked.
+    /// </remarks>
+    private bool TryFindVariableByPrefixFallback(QName name, out object? found)
     {
         // Search scoped variables
         foreach (var scope in _scopes)
@@ -1061,9 +1066,11 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
                     {
                         var evaluated = lazy.GetValueAsync().AsTask().GetAwaiter().GetResult();
                         scope.Variables[varName] = evaluated;
-                        return evaluated;
+                        found = evaluated;
+                        return true;
                     }
-                    return value;
+                    found = value;
+                    return true;
                 }
             }
         }
@@ -1077,13 +1084,16 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
                 {
                     var evaluated = lazyGlobal.GetValueAsync().AsTask().GetAwaiter().GetResult();
                     GlobalVariables[varName] = evaluated;
-                    return evaluated;
+                    found = evaluated;
+                    return true;
                 }
-                return value;
+                found = value;
+                return true;
             }
         }
 
-        return null;
+        found = null;
+        return false;
     }
 
 

--- a/tests/PhoenixmlDb.Xslt.Tests/PrefixedEmptyVariableTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/PrefixedEmptyVariableTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A prefixed variable whose value is the empty sequence is found. Where the prefix reached
+/// evaluation unresolved (inside map and array constructors and quantified expressions), the
+/// variable is looked up by prefix, and that lookup answered null for both "no such variable"
+/// and "found, value ()" — so an empty $p:x was "XPST0008: not bound" while a non-empty one worked.
+/// </summary>
+public sealed class PrefixedEmptyVariableTests
+{
+    private static async Task<string> RunAsync(string select)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:p="urn:p" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:variable name="p:x" select="()"/>
+              <xsl:template match="/"><xsl:variable name="p:local" select="()"/><xsl:value-of select="{select}"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("count(map{'k': $p:x}?k)", "0")]
+    [InlineData("some $i in 1 satisfies empty($p:x)", "true")]
+    [InlineData("count(map{'k': $p:local}?k)", "0")]
+    public async Task AnEmptyPrefixedVariable_IsFound(string select, string expected)
+        => (await RunAsync(select)).Should().Be(expected);
+
+    [Fact]
+    public async Task AnUndefinedPrefixedVariable_IsStillXPST0008()
+    {
+        var act = () => RunAsync("count(map{'k': $p:nope}?k)");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("$p:nope");
+    }
+}


### PR DESCRIPTION
Found by the #53 audit. It's another case of null meaning two things.

In some places a variable's prefix reaches evaluation unresolved: inside map and array constructors and quantified expressions. There the variable is looked up by prefix, and that lookup returned the value, or `null` when nothing matched. **`null` is also the empty sequence**, so a variable holding `()` read as missing:

```xml
<xsl:variable name="p:x" select="()"/>
map{'k': $p:x}      <!-- was: XPST0008 Variable $p:x not bound; a non-empty $p:x worked -->
```

The lookup now reports "found" separately from the value (`TryFindVariableByPrefixFallback`).

### Evidence
- **W3C**, same checkout against the pinned XQuery 1.7.0: no case changes.
- 4 new tests in `PrefixedEmptyVariableTests`, and **all 4 fail on main**. The undefined-variable case still fails for the right reason after the fix: it guards that XPST0008 remains.
- **Found alongside, and not in this PR:** `count([()](1))` returns 1 rather than 0, even with a literal, so it's independent of this fix. That's the XQuery engine's array/empty-member representation, one of the XQuery-side audit findings, so it's on hold under the XSLT-first order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn