### PR TITLE
fix: unparsed-text-lines returns a sequence of lines

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/UnparsedTextHelper.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/UnparsedTextHelper.cs
@@ -43,6 +43,40 @@ internal static class UnparsedTextHelper
     /// Checks that text does not contain characters forbidden in XML (NUL U+0000).
     /// Throws FOUT1190 if invalid characters are found.
     /// </summary>
+    /// <summary>
+    /// fn:unparsed-text-lines: the text split at each "\r\n", "\r" or "\n", without the empty
+    /// string a final line ending would otherwise leave — as a SEQUENCE of xs:string.
+    /// </summary>
+    /// <remarks>
+    /// Both XSLT overloads returned a <c>List&lt;object&gt;</c>, which the engine carries as an
+    /// XDM array: one item. So <c>count(unparsed-text-lines($f))</c> was 1 and xsl:for-each saw a
+    /// single item whose string value was every line joined by spaces (W3C
+    /// unparsed-text-lines-001/002/003/005). The split also ignored a bare "\r" line ending.
+    /// </remarks>
+    internal static object? SplitLines(string text)
+    {
+        var lines = new List<object?>();
+        var start = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] != '\r' && text[i] != '\n')
+                continue;
+            lines.Add(text[start..i]);
+            if (text[i] == '\r' && i + 1 < text.Length && text[i + 1] == '\n')
+                i++;
+            start = i + 1;
+        }
+        if (start < text.Length)
+            lines.Add(text[start..]);
+        return lines.Count switch
+        {
+            0 => null,
+            1 => lines[0],
+            _ => lines.ToArray(),
+        };
+    }
+
+
     internal static void ValidateTextContent(string text)
     {
         if (text.Contains('\0', StringComparison.Ordinal))

--- a/src/PhoenixmlDb.Xslt/Engine/XsltUnparsedTextLines2Function.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltUnparsedTextLines2Function.cs
@@ -61,10 +61,7 @@ internal sealed class XsltUnparsedTextLines2Function : PhoenixmlDb.XQuery.Ast.XQ
             if (policyText != null)
             {
                 UnparsedTextHelper.ValidateTextContent(policyText);
-                var policyLines = policyText.Split('\n').Select(l => (object)l.TrimEnd('\r')).ToList();
-                if (policyLines.Count > 0 && ((string)policyLines[^1]).Length == 0)
-                    policyLines.RemoveAt(policyLines.Count - 1);
-                return policyLines;
+                return UnparsedTextHelper.SplitLines(policyText);
             }
 
             var filePath = UnparsedTextHelper.ResolveFilePath(href, _context._stylesheet.BaseUri);
@@ -72,16 +69,13 @@ internal sealed class XsltUnparsedTextLines2Function : PhoenixmlDb.XQuery.Ast.XQ
             {
                 var text = await System.IO.File.ReadAllTextAsync(filePath, encoding).ConfigureAwait(false);
                 UnparsedTextHelper.ValidateTextContent(text);
-                var lines = text.Split('\n').Select(l => (object)l.TrimEnd('\r')).ToList();
-                if (lines.Count > 0 && ((string)lines[^1]).Length == 0)
-                    lines.RemoveAt(lines.Count - 1);
-                return lines;
+                return UnparsedTextHelper.SplitLines(text);
             }
         }
         catch (IOException)
         {
             // Return empty for inaccessible resources
         }
-        return new List<object>();
+        return null;
     }
 }

--- a/src/PhoenixmlDb.Xslt/Engine/XsltUnparsedTextLinesFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltUnparsedTextLinesFunction.cs
@@ -47,10 +47,7 @@ internal sealed class XsltUnparsedTextLinesFunction : PhoenixmlDb.XQuery.Ast.XQu
             if (policyText != null)
             {
                 UnparsedTextHelper.ValidateTextContent(policyText);
-                var policyLines = policyText.Split('\n').Select(l => (object)l.TrimEnd('\r')).ToList();
-                if (policyLines.Count > 0 && ((string)policyLines[^1]).Length == 0)
-                    policyLines.RemoveAt(policyLines.Count - 1);
-                return policyLines;
+                return UnparsedTextHelper.SplitLines(policyText);
             }
 
             var filePath = UnparsedTextHelper.ResolveFilePath(href, _context._stylesheet.BaseUri);
@@ -58,16 +55,13 @@ internal sealed class XsltUnparsedTextLinesFunction : PhoenixmlDb.XQuery.Ast.XQu
             {
                 var text = await UnparsedTextHelper.ReadWithEncodingDetectionAsync(filePath).ConfigureAwait(false);
                 UnparsedTextHelper.ValidateTextContent(text);
-                var lines = text.Split('\n').Select(l => (object)l.TrimEnd('\r')).ToList();
-                if (lines.Count > 0 && ((string)lines[^1]).Length == 0)
-                    lines.RemoveAt(lines.Count - 1);
-                return lines;
+                return UnparsedTextHelper.SplitLines(text);
             }
         }
         catch (IOException)
         {
             // Return empty for inaccessible resources
         }
-        return new List<object>();
+        return null;
     }
 }

--- a/tests/PhoenixmlDb.Xslt.Tests/UnparsedTextLinesTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/UnparsedTextLinesTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// fn:unparsed-text-lines returns a sequence of lines. The XSLT overloads returned a list the
+/// engine carries as an XDM array — one item — so count() was 1 and xsl:for-each saw a single
+/// item whose string value was every line joined by spaces (W3C unparsed-text-lines-001..005).
+/// </summary>
+public sealed class UnparsedTextLinesTests
+{
+    [Theory]
+    [InlineData("a\nb\nc", "a|b|c")]
+    [InlineData("a\r\nb\r\nc", "a|b|c")]
+    [InlineData("a\rb\rc", "a|b|c")]          // a bare CR is a line ending too
+    [InlineData("a\nb\n", "a|b")]              // no empty line after the final line ending
+    [InlineData("a\n\nb", "a||b")]             // an empty line in the middle is kept
+    [InlineData("only", "only")]
+    [InlineData("", "")]
+    public void SplitLines_FollowsTheSpec(string text, string expected)
+    {
+        var lines = UnparsedTextHelper.SplitLines(text) switch
+        {
+            null => [],
+            object?[] many => many.Select(l => (string)l!).ToArray(),
+            var one => [(string)one],
+        };
+        string.Join('|', lines).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task UnparsedTextLines_IsASequence()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"utl-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(path, "one\ntwo\nthree\n");
+        try
+        {
+            var href = new Uri(path).AbsoluteUri;
+            var ss = $"""
+                <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                  <xsl:output method="text"/>
+                  <xsl:template match="/"><xsl:value-of select="count(unparsed-text-lines('{href}'))"/>|<xsl:for-each select="unparsed-text-lines('{href}', 'utf-8')">[<xsl:value-of select="."/>]</xsl:for-each></xsl:template>
+                </xsl:stylesheet>
+                """;
+            var t = new XsltTransformer();
+            await t.LoadStylesheetAsync(ss);
+            (await t.TransformAsync("<doc/>")).Trim().Should().Be("3|[one][two][three]");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
Both XSLT `unparsed-text-lines` overloads returned a `List<object>`, which the engine carries as an **XDM array**, i.e. one item. As a result:
- `count(unparsed-text-lines($f))` was 1.
- `xsl:for-each` saw a single item whose string value was every line joined by spaces.

This accounted for W3C unparsed-text-lines-001/002/003/005.

Both overloads now share `UnparsedTextHelper.SplitLines`. It returns a **sequence** and follows the spec's `tokenize(unparsed-text($href), '\r\n|\r|\n')`, dropping the empty string a final line ending would leave. The old split also missed a bare `\r` line ending.

### Evidence
- **W3C**, against the pinned XQuery 1.7.0: unparsed-text-lines-001, 002, 003 and 005 now pass, with zero real per-set losses. call-template-1002 is the known flicker.
- 8 new tests: the splitter's line-ending cases (`\n`, `\r\n`, bare `\r`, trailing newline, empty middle line, a single line, empty text), plus the function end to end.
- The unit suite passes on net10.0 under strict string values: 1,558 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn