### PR TITLE
fix: id() finds an xml:id by its normalized value

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -3174,7 +3174,8 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
         foreach (var attrId in element.Attributes)
         {
             if (store.GetNode(attrId) is XdmAttribute attr
-                && attr.LocalName == "id" && attr.Prefix == "xml" && attr.Value == id)
+                && attr.LocalName == "id" && attr.Prefix == "xml"
+                && XsltIdFunction.NormalizeIdValue(attr.Value) == id)
                 return element;
         }
         // Recurse into children

--- a/src/PhoenixmlDb.Xslt/Engine/XsltIdFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltIdFunction.cs
@@ -65,13 +65,24 @@ internal sealed class XsltIdFunction : PhoenixmlDb.XQuery.Ast.XQueryFunction
         return results.ToArray();
     }
 
+    // XML whitespace: the separators fn:id tokenizes on, and what ID normalization strips.
+    private static readonly char[] XmlWhitespace = [' ', '\t', '\n', '\r'];
+
+    /// <summary>
+    /// An ID attribute's value as an ID: whitespace-normalized. The xml:id specification requires
+    /// it ("the value is normalized as if the attribute were declared ID"), so
+    /// <c>xml:id="id3 "</c> is the ID <c>id3</c>. Comparing the raw value missed it: id('id3')
+    /// found nothing (W3C key-076).
+    /// </summary>
+    internal static string NormalizeIdValue(string value) => value.Trim(XmlWhitespace);
+
     internal static void CollectIdValues(object? arg, HashSet<string> ids)
     {
         if (arg == null)
             return;
         if (arg is string s)
         {
-            foreach (var part in s.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            foreach (var part in s.Split(XmlWhitespace, StringSplitOptions.RemoveEmptyEntries))
                 ids.Add(part);
         }
         else if (arg is object?[] arr)
@@ -86,12 +97,14 @@ internal sealed class XsltIdFunction : PhoenixmlDb.XQuery.Ast.XQueryFunction
         }
         else if (arg is XdmNode node)
         {
-            foreach (var part in node.StringValue.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            foreach (var part in node.StringValue.Split(XmlWhitespace, StringSplitOptions.RemoveEmptyEntries))
                 ids.Add(part);
         }
         else
         {
-            ids.Add(arg.ToString()!);
+            // xs:untypedAtomic and the like: tokenized like any other string value.
+            foreach (var part in arg.ToString()!.Split(XmlWhitespace, StringSplitOptions.RemoveEmptyEntries))
+                ids.Add(part);
         }
     }
 
@@ -102,7 +115,7 @@ internal sealed class XsltIdFunction : PhoenixmlDb.XQuery.Ast.XQueryFunction
         {
             foreach (var attr in store.GetAttributes(elem))
             {
-                if (attr.IsId && ids.Contains(attr.Value))
+                if (attr.IsId && ids.Contains(NormalizeIdValue(attr.Value)))
                 {
                     results.Add(elem);
                     break; // Only add the element once

--- a/tests/PhoenixmlDb.Xslt.Tests/XmlIdNormalizationTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/XmlIdNormalizationTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// An xml:id value is whitespace-normalized as an ID, so <c>xml:id="id3 "</c> is the ID
+/// <c>id3</c>; and fn:id tokenizes its argument on any XML whitespace, not only the space
+/// character. id() compared the raw attribute value and split on ' ' alone (W3C key-076).
+/// </summary>
+public sealed class XmlIdNormalizationTests
+{
+    private const string Source = """
+        <doc><div xml:id="id3 "><title>Expressions</title></div><div xml:id="id4"><title>Four</title></div></doc>
+        """;
+
+    private static async Task<string> RunAsync(string select)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="text"/>
+              <xsl:template match="/"><xsl:value-of select="{select}"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync(Source)).Trim();
+    }
+
+    [Theory]
+    [InlineData("id('id3')/title", "Expressions")]
+    [InlineData("id(' id3')/title", "Expressions")]
+    [InlineData("count(id('id3&#9;id4'))", "2")]
+    [InlineData("count(id('id3&#10;id4'))", "2")]
+    [InlineData("count(id(xs:untypedAtomic('id3 id4')))", "2")]
+    public async Task IdFindsAnXmlIdByItsNormalizedValue(string select, string expected)
+        => (await RunAsync(select.Replace("xs:untypedAtomic", "Q{http://www.w3.org/2001/XMLSchema}untypedAtomic", StringComparison.Ordinal)))
+            .Should().Be(expected);
+}


### PR DESCRIPTION
Three fixes to how `id()` matches IDs:
- **Normalized values.** The xml:id specification normalizes the value as an ID, so `xml:id="id3 "` is the ID `id3`. `id()` compared the raw attribute value and found nothing (W3C **key-076**). The xml:id fragment lookup had the same bug.
- **Whitespace tokenizing.** `fn:id` tokenizes its argument on any XML whitespace. `id()` split on the space character alone, so a tab- or newline-separated IDREFS list was treated as one token.
- **Non-string arguments.** An `xs:untypedAtomic` argument wasn't tokenized at all.

### Evidence
- **W3C**, same checkout against the pinned XQuery 1.7.0: key-076 passes, with zero per-set losses.
- 5 new tests in `XmlIdNormalizationTests`, **all failing on main**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn