### PR TITLE
fix: xsl:merge for-each-source loads xs:anyURI sources

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
@@ -380,9 +380,23 @@ internal sealed partial class DefaultXsltExecutionContext
 
                 foreach (var item in forEachItems)
                 {
-                    // for-each-source evaluates to URI strings; load each via doc()
+                    // for-each-source is xs:string*, so each item is a URI to load via doc(). The
+                    // function conversion rules admit xs:anyURI (promoted) and xs:untypedAtomic
+                    // (cast) as well as xs:string: uri-collection() returns xs:anyURI, and an
+                    // xs:anyURI item used to become the context item itself, so
+                    // select="events/event" failed "axis step ... context item is not a node"
+                    // (W3C merge-039/098). Any other atomic type is XPTY0004 (merge-043:
+                    // for-each-source="1 to 5"). Nodes keep their existing handling.
                     object contextItem = item;
-                    if (item is string uri)
+                    var uri = item switch
+                    {
+                        string str => str,
+                        Xdm.XsAnyUri anyUri => anyUri.Value,
+                        Xdm.XsUntypedAtomic ua => ua.Value,
+                        null or XdmNode => null,
+                        _ => throw Error($"XPTY0004: for-each-source must yield URIs (xs:string*); got {item.GetType().Name}"),
+                    };
+                    if (uri != null)
                     {
                         var doc = _policyResolver?.ResolveDocument(uri) ?? _documentResolver.ResolveDocument(uri);
                         if (doc == null)

--- a/tests/PhoenixmlDb.Xslt.Tests/MergeForEachSourceTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/MergeForEachSourceTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// xsl:merge-source/@for-each-source is xs:string*: each item is a URI to load. The function
+/// conversion rules admit xs:anyURI and xs:untypedAtomic too, but only a .NET string was loaded —
+/// an xs:anyURI (what uri-collection returns) became the context item itself and select failed
+/// on it (W3C merge-039/098). Any other atomic type is XPTY0004 (merge-043).
+/// </summary>
+public sealed class MergeForEachSourceTests
+{
+    private static async Task<string> RunAsync(string forEachSource)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:template match="/">
+                <xsl:merge>
+                  <xsl:merge-source for-each-source="{forEachSource}" select="r/e">
+                    <xsl:merge-key select="@k"/>
+                  </xsl:merge-source>
+                  <xsl:merge-action><xsl:value-of select="current-merge-key()"/></xsl:merge-action>
+                </xsl:merge>
+              </xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Fact]
+    public async Task AnAnyUriSource_IsLoaded()
+    {
+        var a = Path.Combine(Path.GetTempPath(), $"m-{Guid.NewGuid():N}.xml");
+        var b = Path.Combine(Path.GetTempPath(), $"m-{Guid.NewGuid():N}.xml");
+        await File.WriteAllTextAsync(a, "<r><e k='1'/><e k='3'/></r>");
+        await File.WriteAllTextAsync(b, "<r><e k='2'/></r>");
+        try
+        {
+            var (ua, ub) = (new Uri(a).AbsoluteUri, new Uri(b).AbsoluteUri);
+            (await RunAsync($"(xs:anyURI('{ua}'), xs:untypedAtomic('{ub}'))")).Should().Be("123");
+        }
+        finally
+        {
+            File.Delete(a);
+            File.Delete(b);
+        }
+    }
+
+    [Fact]
+    public async Task ANonUriSource_IsXPTY0004()
+    {
+        var act = () => RunAsync("1 to 2");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XPTY0004");
+    }
+}


### PR DESCRIPTION
`xsl:merge-source/@for-each-source` has type `xs:string*`, so each item is a URI to load with `doc()`. The function conversion rules admit `xs:anyURI` (by promotion) and `xs:untypedAtomic` (by cast), but **only a .NET string was loaded**.

An `xs:anyURI` item, which is what `uri-collection()` returns, became the context item itself. So `select="events/event"` failed with *"axis step … context item is not a node (got XsAnyUri)"* (W3C **merge-039**, **merge-098**).

Under the same rules, any other atomic type is **XPTY0004** (**merge-043**, `for-each-source="1 to 5"`). That case previously surfaced as the same wrong axis-step error. Node items keep their existing handling.

### Evidence
- **W3C**, same checkout against the pinned XQuery 1.7.0: merge-039, merge-043 and merge-098 now pass, with zero per-set losses.
- 2 new tests in `MergeForEachSourceTests`: `xs:anyURI` and `xs:untypedAtomic` sources are loaded and merged, and an integer source raises XPTY0004. **Both fail on main.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn