### PR TITLE
fix: current-merge-key() with no current key is XTDE3510

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/XsltCurrentMergeKeyFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltCurrentMergeKeyFunction.cs
@@ -23,13 +23,15 @@ internal sealed class XsltCurrentMergeKeyFunction : PhoenixmlDb.XQuery.Ast.XQuer
     public override QName Name => new(PhoenixmlDb.XQuery.Functions.FunctionNamespaces.Fn, "current-merge-key");
     public override XdmSequenceType ReturnType => XdmSequenceType.OptionalItem;
     public override IReadOnlyList<FunctionParameterDef> Parameters => [];
-    public override string? DynamicCallErrorCode => "XTDE3480";
+    // XTDE3510, not XTDE3480: the spec gives current-merge-key its own code (§15.4, "used when
+    // the current merge key is absent"); XTDE3480 is current-merge-group's. W3C merge-056/101.
+    public override string? DynamicCallErrorCode => "XTDE3510";
     public override ValueTask<object?> InvokeAsync(
         IReadOnlyList<object?> arguments, PhoenixmlDb.XQuery.Ast.ExecutionContext context)
     {
         if (_context.TryGetVariable(new QName(NamespaceId.None, "current-merge-key"), out var key) && key != null)
             return ValueTask.FromResult<object?>(key);
 
-        throw new XsltException("XTDE3480: current-merge-key() called when there is no current merge key");
+        throw new XsltException("XTDE3510: current-merge-key() called when there is no current merge key");
     }
 }

--- a/tests/PhoenixmlDb.Xslt.Tests/CurrentMergeKeyErrorTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/CurrentMergeKeyErrorTests.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// current-merge-key() with no current merge key is XTDE3510 (XSLT 3.0 §15.4). It raised
+/// XTDE3480, which is current-merge-group's code (W3C merge-056, merge-101).
+/// </summary>
+public sealed class CurrentMergeKeyErrorTests
+{
+    private static async Task RunAsync(string body)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="text"/>
+              <xsl:template match="/">{body}</xsl:template>
+              <xsl:template name="n"><xsl:value-of select="current-merge-key()"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        await t.TransformAsync("<doc><e k='1'/></doc>");
+    }
+
+    [Theory]
+    [InlineData("""<xsl:value-of select="current-merge-key()"/>""")]
+    // Called from a named template inside a merge action: the key is not visible there.
+    [InlineData("""<xsl:merge><xsl:merge-source select="doc/e"><xsl:merge-key select="@k"/></xsl:merge-source><xsl:merge-action><xsl:call-template name="n"/></xsl:merge-action></xsl:merge>""")]
+    public async Task CurrentMergeKey_WithNoCurrentKey_IsXTDE3510(string body)
+    {
+        var act = () => RunAsync(body);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTDE3510");
+    }
+}


### PR DESCRIPTION
XSLT 3.0 §15.4 gives `current-merge-key()` its own error: **XTDE3510**, *"used when the current merge key is absent"*. The function raised **XTDE3480**, which is `current-merge-group()`'s code, both for a direct call and as its dynamic-call error code.

### Evidence
- **W3C**, same checkout against the pinned XQuery 1.7.0: **merge-056**, **merge-101** and **error-3510a** now pass, with zero per-set losses.
- 2 new tests in `CurrentMergeKeyErrorTests`: a direct call outside a merge, and a call from a named template inside a merge action, where the key isn't visible. **Both fail on main**, which raises XTDE3480.

A related latent issue that this PR doesn't change: "no current key" is marked by a null variable, which is also how an empty merge key would read. I've recorded it for the register, but there's no failing case for it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn