### PR TITLE
fix: xsl:merge for-each-source resolves against the static base URI

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
@@ -422,9 +422,14 @@ internal sealed partial class DefaultXsltExecutionContext
                     };
                     if (uri != null)
                     {
-                        var doc = _policyResolver?.ResolveDocument(uri) ?? _documentResolver.ResolveDocument(uri);
-                        if (doc == null)
-                            continue;
+                        // Relative to the static base URI in scope — which xml:base on the xsl:merge
+                        // or an ancestor changes — as doc() would resolve it. It went to the
+                        // resolver raw, so it resolved against the stylesheet's own base, and a source
+                        // that could not be found was skipped in silence: merge-041's second source
+                        // (xml:base="../../" plus 'insn/merge/log-file-2.xml') contributed nothing.
+                        uri = ResolveAgainstStaticBaseUri(uri);
+                        var doc = _policyResolver?.ResolveDocument(uri) ?? _documentResolver.ResolveDocument(uri)
+                            ?? throw Error($"FODC0002: for-each-source document '{uri}' cannot be retrieved");
                         contextItem = doc;
 
                         // Compute specified accumulators on the merge source document
@@ -638,6 +643,16 @@ internal sealed partial class DefaultXsltExecutionContext
         keyed.Sort((a, b) => CompareMergeKeys(a.Keys, b.Keys, orders, dataTypes, collations));
 
         return keyed.Select(k => k.Item).ToList();
+    }
+
+
+    /// <summary>A URI resolved against the static base URI in scope (absolute URIs unchanged).</summary>
+    private string ResolveAgainstStaticBaseUri(string uri)
+    {
+        if (Uri.TryCreate(uri, UriKind.Absolute, out _) || StaticBaseUri is not { } staticBase
+            || !Uri.TryCreate(staticBase, UriKind.Absolute, out var baseUri))
+            return uri;
+        return new Uri(baseUri, uri).AbsoluteUri;
     }
 
 

--- a/tests/PhoenixmlDb.Xslt.Tests/MergeForEachSourceBaseUriTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/MergeForEachSourceBaseUriTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A relative for-each-source URI resolves against the static base URI in scope — which xml:base
+/// on the xsl:merge changes — as doc() would; and a source that cannot be retrieved is FODC0002.
+/// The URI went to the resolver raw, and an unretrievable source was skipped in silence, so a
+/// source addressed relative to an xml:base contributed nothing (W3C merge-041).
+/// </summary>
+public sealed class MergeForEachSourceBaseUriTests
+{
+    private static async Task<string> RunAsync(string mergeAttributes, string forEachSource)
+    {
+        var ss = $$"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="text"/>
+              <xsl:template match="/">
+                <xsl:merge {{mergeAttributes}}>
+                  <xsl:merge-source for-each-source="{{forEachSource}}" select="r/e"><xsl:merge-key select="@k"/></xsl:merge-source>
+                  <xsl:merge-action><xsl:value-of select="current-merge-key()"/></xsl:merge-action>
+                </xsl:merge>
+              </xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Fact]
+    public async Task ARelativeSource_ResolvesAgainstXmlBase()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mb-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, "in.xml"), "<r><e k='1'/><e k='2'/></r>");
+        try
+        {
+            var baseUri = new Uri(dir + Path.DirectorySeparatorChar).AbsoluteUri;
+            (await RunAsync($"xml:base=\"{baseUri}\"", "'in.xml'")).Should().Be("12");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AnUnretrievableSource_IsFODC0002()
+    {
+        var missing = new Uri(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.xml")).AbsoluteUri;
+        var act = () => RunAsync("", $"'{missing}'");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("FODC0002");
+    }
+}


### PR DESCRIPTION
Two problems with how `for-each-source` documents were located:
- **Wrong base.** A relative `for-each-source` URI went to the document resolver as-is, so it resolved against the stylesheet's own base and ignored `xml:base` on the `xsl:merge` or any ancestor.
- **Silent skip.** A source that couldn't be retrieved was skipped without any error.

Together, W3C **merge-041** (`xml:base="../../"` with `'insn/merge/log-file-2.xml'`) lost its entire second source and still produced output.

The URI now resolves against the static base URI in scope, as `doc()` does, and a source that can't be retrieved raises **FODC0002**.

### Evidence
- **W3C**, same checkout against the pinned XQuery 1.7.0: merge-041 passes, with zero per-set losses. Nothing relied on the silent skip.
- 2 new tests in `MergeForEachSourceBaseUriTests`, **both failing on main**: a relative source resolves under `xml:base`, and an unretrievable source raises FODC0002.
- This is rebased onto #42, which touches the same code. The unit suite passes on the combination: 1,575 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn