### PR TITLE
Reject non-streamable streamable merge sources (XTSE3430)

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/StreamabilityChecker.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StreamabilityChecker.cs
@@ -71,6 +71,33 @@ internal static class StreamabilityChecker
     }
 
     /// <summary>
+    /// Checks an xsl:merge-source streamable="yes" (XSLT 3.0 §15.6). Its select is evaluated
+    /// against the streamed document, so it must stride — a descendant step is crawling — and it
+    /// cannot sort before merging, which needs the whole input. Throws XTSE3430 otherwise.
+    /// </summary>
+    /// <remarks>
+    /// Merge sources were not checked at all: the checker walked only the merge action, so
+    /// select="log//record" (W3C merge-094) and sort-before-merge="yes" (merge-095) ran as if
+    /// streamable.
+    /// </remarks>
+    public static void CheckStreamableMergeSource(XsltMergeSource source)
+    {
+        if (!source.Streamable)
+            return;
+        if (source.SortBeforeMerge)
+            throw new XsltException(
+                "XTSE3430: xsl:merge-source with streamable=\"yes\" is not guaranteed streamable: sort-before-merge=\"yes\" needs the whole input",
+                source.Location);
+        var crawling = new DescendantAxisDetector();
+        crawling.Walk(source.Select);
+        if (crawling.Found)
+            throw new XsltException(
+                "XTSE3430: xsl:merge-source with streamable=\"yes\" is not guaranteed streamable: its select uses a crawling (descendant) step",
+                source.Location);
+    }
+
+
+    /// <summary>
     /// Checks a template body used in a streamable mode.
     /// Throws XsltException with XTSE3430 if the body contains non-streamable expressions.
     /// </summary>

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Grouping.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Grouping.cs
@@ -1125,7 +1125,7 @@ public sealed partial class StylesheetParser
             }
         }
 
-        return new XsltMergeSource
+        var mergeSource = new XsltMergeSource
         {
             Name = nameAttr?.Value,
             Location = location,
@@ -1141,6 +1141,8 @@ public sealed partial class StylesheetParser
             MergeKeys = mergeKeys,
             UseAccumulators = useAccumulators
         };
+        StreamabilityChecker.CheckStreamableMergeSource(mergeSource);
+        return mergeSource;
     }
 
 

--- a/tests/PhoenixmlDb.Xslt.Tests/StreamableMergeSourceTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/StreamableMergeSourceTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// An xsl:merge-source with streamable="yes" must be guaranteed streamable (XTSE3430): its select
+/// strides from the streamed document, and it cannot sort before merging. The streamability check
+/// walked only the merge action, so a crawling select or sort-before-merge ran as if streamable.
+/// </summary>
+public sealed class StreamableMergeSourceTests
+{
+    private static string Stylesheet(string sourceAttributes) => $"""
+        <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+          <xsl:output method="text"/>
+          <xsl:template name="xsl:initial-template">
+            <xsl:merge>
+              <xsl:merge-source for-each-source="'urn:unused'" {sourceAttributes}>
+                <xsl:merge-key select="@k"/>
+              </xsl:merge-source>
+              <xsl:merge-action><xsl:value-of select="current-merge-key()"/></xsl:merge-action>
+            </xsl:merge>
+          </xsl:template>
+        </xsl:stylesheet>
+        """;
+
+    [Theory]
+    [InlineData("""streamable="yes" select="log//record" """)]
+    [InlineData("""streamable="yes" select="descendant::record" """)]
+    [InlineData("""streamable="yes" select="log/record" sort-before-merge="yes" """)]
+    public async Task ANonStreamableSource_MarkedStreamable_IsXTSE3430(string attributes)
+    {
+        var act = () => new XsltTransformer().LoadStylesheetAsync(Stylesheet(attributes));
+        (await act.Should().ThrowAsync<XsltException>()).Which.Message.Should().StartWith("XTSE3430");
+    }
+
+    [Theory]
+    [InlineData("""streamable="yes" select="log/record" """)]
+    [InlineData("""streamable="no" select="log//record" sort-before-merge="yes" """)]
+    [InlineData("""select="log//record" """)]
+    public async Task AStridingOrUnstreamedSource_Compiles(string attributes)
+    {
+        var act = () => new XsltTransformer().LoadStylesheetAsync(Stylesheet(attributes));
+        await act.Should().NotThrowAsync();
+    }
+}


### PR DESCRIPTION
`xsl:merge-source streamable="yes"` must be guaranteed streamable (XSLT 3.0 §15.6 / XTSE3430). The streamability checker only walked `xsl:merge-action`, so sources were never checked.

- `StreamabilityChecker.CheckStreamableMergeSource`: XTSE3430 when the select has a descendant (crawling) step, or when `sort-before-merge="yes"`. Called from `ParseMergeSource`.
- `StreamableMergeSourceTests`: 3 rejection cases (fail on main) and 3 cases that must still compile (striding select, streamable="no", no streamable attribute).

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): merge-094 and merge-095 now pass; +2 with zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn