### PR TITLE
Built-in copy of a document node in a function returns a document node

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
@@ -694,7 +694,9 @@ internal sealed partial class DefaultXsltExecutionContext
                 // Direct-output / streaming keep the existing child-recursion dispatch, as does
                 // any untyped-RTF body (flip-active OR blocked): only a typed as-body sequence
                 // accumulator (InTypedAsBodyAccumulator) delivers the copy as a node item.
-                if (!_isStreamingExecution && InTypedAsBodyAccumulator && _nodeStore != null)
+                // A function body is a sequence constructor too: returning the children there
+                // made f() as="document-node()" an XTTE0780 (W3C merge-096).
+                if (!_isStreamingExecution && (InTypedAsBodyAccumulator || InFunctionBodyProper) && _nodeStore != null)
                     await BuildBuiltInCopyDocNodeAsync(builtinShallowDoc, mode, withParams).ConfigureAwait(false);
                 else if (!_isStreamingExecution)
                     await ApplyTemplatesAsync(null, mode, [], withParams).ConfigureAwait(false);
@@ -951,8 +953,9 @@ internal sealed partial class DefaultXsltExecutionContext
                 // produced. (fn/base-uri 053: deep-copy-doc2.) Direct-output / streaming keep the
                 // existing child-recursion dispatch (a doc node serializes as its children), as
                 // does any untyped-RTF body (flip-active OR blocked): only a typed as-body
-                // sequence accumulator (InTypedAsBodyAccumulator) delivers the copy as a node item.
-                if (!_isStreamingExecution && InTypedAsBodyAccumulator && _nodeStore != null)
+                // sequence accumulator (InTypedAsBodyAccumulator) or a function body delivers the
+                // copy as a node item.
+                if (!_isStreamingExecution && (InTypedAsBodyAccumulator || InFunctionBodyProper) && _nodeStore != null)
                     await BuildBuiltInCopyDocNodeAsync(builtinDeepDoc, mode, withParams).ConfigureAwait(false);
                 else if (!_isStreamingExecution)
                     await ApplyTemplatesAsync(null, mode, [], withParams).ConfigureAwait(false);

--- a/tests/PhoenixmlDb.Xslt.Tests/FunctionBuiltInDocumentCopyTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/FunctionBuiltInDocumentCopyTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// In a function body, the built-in shallow-copy and deep-copy rules copy a document node as a
+/// document node. They built one only in a typed template or variable body; in a function body they
+/// returned the document's children, so f() as="document-node()" was XTTE0780 and an untyped f()
+/// returned the element (W3C merge-096).
+/// </summary>
+public sealed class FunctionBuiltInDocumentCopyTests
+{
+    private static async Task<string> RunAsync(string onNoMatch, string asAttribute)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:f="urn:f" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:mode name="c" on-no-match="{onNoMatch}"/>
+              <xsl:function name="f:copy" {asAttribute}><xsl:param name="n"/><xsl:apply-templates select="$n" mode="c"/></xsl:function>
+              <xsl:template match="/">
+                <xsl:variable name="r" select="f:copy(.)"/>
+                <xsl:value-of select="count($r), $r ! (if (. instance of document-node()) then 'doc' else name()), count($r/a/b), $r is ."/>
+              </xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<a><b/></a>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("shallow-copy", """as="document-node()" """)]
+    [InlineData("shallow-copy", "")]
+    [InlineData("deep-copy", """as="document-node()" """)]
+    [InlineData("deep-copy", "")]
+    public async Task ABuiltInCopyOfADocument_InAFunction_IsANewDocumentNode(string onNoMatch, string asAttribute)
+        => (await RunAsync(onNoMatch, asAttribute)).Should().Be("1 doc 1 false");
+}


### PR DESCRIPTION
In a function body, `apply-templates` on a document node under `on-no-match="shallow-copy"` or `"deep-copy"` returned the document's children, not a new document node. The built-in rule built a document node only when `InTypedAsBodyAccumulator` was set (a typed template or variable body), and a function body is a sequence constructor as well.

- `f() as="document-node()"` raised `XTTE0780: ... requires type Document but got element`.
- An untyped `f()` returned the element.

**Change:** both built-in document cases (shallow-copy, deep-copy) also build the document node when `InFunctionBodyProper` is true. An explicit `xsl:copy` of a document node already worked.

**Tests:** `FunctionBuiltInDocumentCopyTests` covers shallow/deep × typed/untyped. All 4 fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): merge-096 now passes. call-template-1002 showed up as a loss, but it flickers and failed on main in two reruns, so the result is +1 with no real losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn