### PR TITLE
Directory collections; streamable merge sources deliver snapshots

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
@@ -451,6 +451,12 @@ internal sealed partial class DefaultXsltExecutionContext
                     try
                     {
                         var selected = await EvaluateAsync(source.Select).ConfigureAwait(false);
+                        // A streamed source delivers snapshots (each node with copies of its
+                        // ancestors, not the document), so a streamable source read here in
+                        // memory does too: root(current-merge-group()[1]) holds that one item, not
+                        // its siblings (W3C merge-097s, Saxon bug 3883).
+                        if (source.Streamable)
+                            selected = await SnapshotHelper.ProcessSnapshotAsync(selected, this).ConfigureAwait(false);
                         subSequence = new List<object>();
                         AddToList(subSequence, selected);
                     }

--- a/src/PhoenixmlDb.Xslt/Engine/XsltDocumentResolver.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltDocumentResolver.cs
@@ -108,12 +108,8 @@ internal sealed class XsltDocumentResolver : PhoenixmlDb.XQuery.IDocumentResolve
 
     public IEnumerable<XdmNode> ResolveCollection(string? uri)
     {
-        if (_collections == null)
-            return [];
-
-        var key = uri ?? "";
-        if (!_collections.TryGetValue(key, out var paths))
-            return [];
+        if (_collections == null || !_collections.TryGetValue(uri ?? "", out var paths))
+            return uri == null ? [] : ResolveDirectoryCollection(uri);
 
         var nodes = new List<XdmNode>();
         foreach (var path in paths)
@@ -141,6 +137,67 @@ internal sealed class XsltDocumentResolver : PhoenixmlDb.XQuery.IDocumentResolve
             {
                 nodes.Add(doc);
             }
+        }
+        return nodes;
+    }
+
+    /// <summary>
+    /// A collection URI naming a directory is the XML files in it, in path order. The query
+    /// takes <c>select=</c> (a file-name glob using <c>*</c> and <c>?</c>) and <c>recurse=yes</c>,
+    /// separated by <c>;</c> or <c>&amp;</c> — the Saxon form (<c>dir?select=*.xml</c>) the W3C
+    /// suite uses (merge-097). Files that do not parse as XML are left out. Each document is
+    /// resolved as doc() would, so it is the same node doc() returns for its URI.
+    /// </summary>
+    private List<XdmNode> ResolveDirectoryCollection(string uri)
+    {
+        var queryIdx = uri.IndexOf('?', StringComparison.Ordinal);
+        var location = queryIdx >= 0 ? uri[..queryIdx] : uri;
+        string? select = null;
+        var recurse = false;
+        if (queryIdx >= 0)
+        {
+            foreach (var part in uri[(queryIdx + 1)..].Split([';', '&'], StringSplitOptions.RemoveEmptyEntries))
+            {
+                var eq = part.IndexOf('=', StringComparison.Ordinal);
+                if (eq < 0)
+                    continue;
+                var value = Uri.UnescapeDataString(part[(eq + 1)..]);
+                switch (part[..eq])
+                {
+                    case "select": select = value; break;
+                    case "recurse": recurse = value is "yes" or "true" or "1"; break;
+                }
+            }
+        }
+
+        string directory;
+        try
+        {
+            var resolved = ResolveUri(location.Length == 0 ? "." : location);
+            if (!resolved.IsAbsoluteUri || !resolved.IsFile || !System.IO.Directory.Exists(resolved.LocalPath))
+                return [];
+            directory = resolved.LocalPath;
+        }
+        catch (UriFormatException)
+        {
+            return [];
+        }
+
+        var pattern = select == null
+            ? null
+            : new System.Text.RegularExpressions.Regex(
+                "^" + System.Text.RegularExpressions.Regex.Escape(select).Replace("\\*", ".*", StringComparison.Ordinal).Replace("\\?", ".", StringComparison.Ordinal) + "$",
+                System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+        var files = System.IO.Directory.EnumerateFiles(directory, "*",
+                recurse ? System.IO.SearchOption.AllDirectories : System.IO.SearchOption.TopDirectoryOnly)
+            .Where(f => pattern == null || pattern.IsMatch(System.IO.Path.GetFileName(f)))
+            .Order(StringComparer.Ordinal);
+
+        var nodes = new List<XdmNode>();
+        foreach (var file in files)
+        {
+            if (ResolveDocument(new Uri(file).AbsoluteUri) is { } doc)
+                nodes.Add(doc);
         }
         return nodes;
     }

--- a/tests/PhoenixmlDb.Xslt.Tests/DirectoryCollectionTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/DirectoryCollectionTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A collection URI naming a directory is the XML files in it; the query selects by file-name
+/// glob (<c>select=</c>) and can recurse (<c>recurse=yes</c>). Only collections registered by the
+/// host resolved, so <c>uri-collection('dir?select=*.xml')</c> was FODC0002 (W3C merge-097).
+/// </summary>
+public sealed class DirectoryCollectionTests : IDisposable
+{
+    private readonly string _dir = Directory.CreateTempSubdirectory("phoenixml-coll-").FullName;
+
+    public DirectoryCollectionTests()
+    {
+        File.WriteAllText(Path.Combine(_dir, "b.xml"), "<r><item>b1</item><item>b2</item></r>");
+        File.WriteAllText(Path.Combine(_dir, "a.xml"), "<r><item>a1</item><item>a2</item></r>");
+        File.WriteAllText(Path.Combine(_dir, "notes.txt"), "not xml");
+        Directory.CreateDirectory(Path.Combine(_dir, "sub"));
+        File.WriteAllText(Path.Combine(_dir, "sub", "c.xml"), "<r><item>c1</item></r>");
+    }
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string DirUri => new Uri(_dir + Path.DirectorySeparatorChar).AbsoluteUri;
+
+    private static async Task<string> RunAsync(string body)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:template match="/">{body}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("?select=*.xml", "a.xml b.xml")]
+    [InlineData("?select=a*", "a.xml")]
+    [InlineData("?select=?.xml;recurse=yes", "a.xml b.xml c.xml")]
+    [InlineData("", "a.xml b.xml")]
+    public async Task ADirectoryUri_IsTheXmlFilesInIt(string query, string expected)
+        => (await RunAsync($"""<xsl:value-of select="uri-collection('{DirUri}{query}') ! tokenize(., '/')[last()]"/>"""))
+            .Should().Be(expected);
+
+    [Fact]
+    public async Task ADirectoryCollection_HoldsTheSameDocumentsAsDoc()
+        => (await RunAsync($"""<xsl:value-of select="let $c := collection('{DirUri}?select=*.xml') return (count($c//item), $c[1] is doc(document-uri($c[1])))"/>"""))
+            .Should().Be("4 true");
+
+    /// <summary>
+    /// A streamable merge source delivers snapshots, even where the merge runs in memory: the
+    /// group's first item has its ancestors but not its siblings (W3C merge-097s).
+    /// </summary>
+    [Theory]
+    [InlineData("yes", "1")]
+    [InlineData("no", "2")]
+    public async Task AStreamableMergeSource_DeliversSnapshots(string streamable, string expected)
+        => (await RunAsync($"""
+            <xsl:merge>
+              <xsl:merge-source for-each-source="'{DirUri}a.xml'" select="*/*" streamable="{streamable}">
+                <xsl:merge-key select="true()"/>
+              </xsl:merge-source>
+              <xsl:merge-action><xsl:value-of select="count(root(current-merge-group()[1])//item)"/></xsl:merge-action>
+            </xsl:merge>
+            """)).Should().Be(expected);
+}


### PR DESCRIPTION
**Directory collections.** `XsltDocumentResolver.ResolveCollection` only knew host-registered collections, so `uri-collection('.?select=merge-097-*.xml')` was FODC0002. A collection URI that names a directory now resolves to the XML files in it, in ordinal path order. It follows the Saxon form used by the W3C suite:
- `select=` is a file-name glob using `*` and `?`.
- `recurse=yes` descends into subdirectories.
- Parameters are separated by `;` or `&`.
- Files that don't parse as XML are skipped.
- Each document comes from `ResolveDocument`, so `collection()[1] is doc(document-uri(collection()[1]))`.

Registered collections are checked first and are unchanged.

**Streamable merge sources deliver snapshots.** A `streamable="yes"` source whose select isn't a simple child step (e.g. `*/*/*`) runs on the in-memory path, and it handed out the original nodes. A streamed source delivers snapshots, so `root(current-merge-group()[1])` should hold that item and its ancestors, not its siblings (Saxon bug 3883). The fallback now applies `snapshot()` to a streamable source's items.

**Tests:** `DirectoryCollectionTests` covers glob, recursion, no query, doc identity, and snapshot vs non-streamable. 6 of the 7 fail on main; the `streamable="no"` control passes on both.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): merge-079, merge-097 and merge-097s now pass; +3 with zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn