### PR TITLE
XTDE3362 for a declared accumulator not applicable to the tree

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorAfterFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorAfterFunction.cs
@@ -59,8 +59,13 @@ internal sealed class XsltAccumulatorAfterFunction : PhoenixmlDb.XQuery.Ast.XQue
         await _context.EnsureAccumulatorsComputedAsync(accName, node).ConfigureAwait(false);
         await _context.EnsureAccumulatorPhaseAsync(accName, node, isAfter: true).ConfigureAwait(false);
 
+        // A declared accumulator with no value here was not applicable to this node's tree —
+        // e.g. not in the merge source's use-accumulators — which is XTDE3362; XTDE3340 is for a
+        // name that is not an accumulator at all (W3C merge-067).
         var values = _context.GetAccumulatorValue(accName, node, isAfter: true)
-            ?? throw new XsltException($"XTDE3340: No accumulator named '{name}' is available for the current node");
+            ?? throw new XsltException(_context._stylesheet.Accumulators.ContainsKey(accName)
+                ? $"XTDE3362: Accumulator '{name}' is not applicable to the tree containing the context node"
+                : $"XTDE3340: No accumulator named '{name}' is available for the current node");
 
         // Re-throw deferred errors from accumulator evaluation
         if (values.after is AccumulatorDeferredError deferredError)

--- a/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
@@ -59,8 +59,13 @@ internal sealed class XsltAccumulatorBeforeFunction : PhoenixmlDb.XQuery.Ast.XQu
         await _context.EnsureAccumulatorsComputedAsync(accName, node).ConfigureAwait(false);
         await _context.EnsureAccumulatorPhaseAsync(accName, node, isAfter: false).ConfigureAwait(false);
 
+        // A declared accumulator with no value here was not applicable to this node's tree —
+        // e.g. not in the merge source's use-accumulators — which is XTDE3362; XTDE3340 is for a
+        // name that is not an accumulator at all (W3C merge-067).
         var values = _context.GetAccumulatorValue(accName, node)
-            ?? throw new XsltException($"XTDE3340: No accumulator named '{name}' is available for the current node");
+            ?? throw new XsltException(_context._stylesheet.Accumulators.ContainsKey(accName)
+                ? $"XTDE3362: Accumulator '{name}' is not applicable to the tree containing the context node"
+                : $"XTDE3340: No accumulator named '{name}' is available for the current node");
 
         // Re-throw deferred errors from accumulator evaluation
         if (values.before is AccumulatorDeferredError deferredError)

--- a/tests/PhoenixmlDb.Xslt.Tests/AccumulatorNotApplicableTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/AccumulatorNotApplicableTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Reading a declared accumulator on a tree it does not apply to — a document loaded with
+/// use-accumulators that leaves it out — is XTDE3362. It was reported as XTDE3340, the code for a
+/// name that is not an accumulator (W3C merge-067, non-stream-201).
+/// </summary>
+public sealed class AccumulatorNotApplicableTests : IDisposable
+{
+    private readonly string _file = Path.Combine(Path.GetTempPath(), $"phoenixml-acc-{Guid.NewGuid():N}.xml");
+
+    public AccumulatorNotApplicableTests() => File.WriteAllText(_file, "<r><x/><x/></r>");
+
+    public void Dispose() => File.Delete(_file);
+
+    private async Task<string> RunAsync(string function, string accumulator)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="text"/>
+              <xsl:accumulator name="a" initial-value="0"><xsl:accumulator-rule match="x" select="$value + 1"/></xsl:accumulator>
+              <xsl:accumulator name="b" initial-value="0"><xsl:accumulator-rule match="x" select="$value + 1"/></xsl:accumulator>
+              <xsl:template match="/">
+                <xsl:source-document href="{new Uri(_file).AbsoluteUri}" use-accumulators="a">
+                  <xsl:value-of select="r/x[2]/{function}('{accumulator}')"/>
+                </xsl:source-document>
+              </xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    [Theory]
+    [InlineData("accumulator-before", "2")]
+    [InlineData("accumulator-after", "2")]
+    public async Task AnApplicableAccumulator_IsRead(string function, string expected)
+        => (await RunAsync(function, "a")).Should().Be(expected);
+
+    [Theory]
+    [InlineData("accumulator-before")]
+    [InlineData("accumulator-after")]
+    public async Task ADeclaredAccumulator_LeftOutOfUseAccumulators_IsXTDE3362(string function)
+    {
+        var act = () => RunAsync(function, "b");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTDE3362");
+    }
+
+    [Theory]
+    [InlineData("accumulator-before")]
+    [InlineData("accumulator-after")]
+    public async Task AnUndeclaredName_IsStillXTDE3340(string function)
+    {
+        var act = () => RunAsync(function, "nope");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTDE3340");
+    }
+}


### PR DESCRIPTION
`accumulator-before()` and `accumulator-after()` fell through to `XTDE3340: No accumulator named '…' is available` whenever the accumulator had no value for the node. Per XSLT 3.0 §18.2:
- XTDE3340 is for a name that isn't a declared accumulator.
- XTDE3362 is for a declared accumulator that isn't applicable to the tree containing the context node, e.g. a document loaded by `xsl:merge-source` or `xsl:source-document` whose `use-accumulators` leaves it out.

**Change:** at that fallthrough, if the accumulator is declared the error is XTDE3362; otherwise it stays XTDE3340. The mode-applicability branch above it is unchanged (XTDE3362 on the principal tree, from e07fd58).

**Tests:** `AccumulatorNotApplicableTests` covers the applicable accumulator (read), a declared one left out of `use-accumulators` (XTDE3362) and an undeclared name (XTDE3340), each for before and after. The 2 XTDE3362 cases fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): merge-067 and non-stream-201 now pass; +2 with zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn