### PR TITLE
Seven XSLT error codes that named the wrong rule

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
@@ -1478,7 +1478,17 @@ internal sealed partial class DefaultXsltExecutionContext
         pattern = PhoenixmlDb.XQuery.Functions.XQueryRegexHelper.FixDotForSurrogatePairs(pattern,
             flags.Contains('s', StringComparison.Ordinal));
 
-        var regex = new System.Text.RegularExpressions.Regex(pattern, regexOptions);
+        System.Text.RegularExpressions.Regex regex;
+        try
+        {
+            regex = new System.Text.RegularExpressions.Regex(pattern, regexOptions);
+        }
+        catch (ArgumentException ex)
+        {
+            // The .NET parser's rejection (e.g. regex="[A-Z", an unterminated class) escaped
+            // with no error code (error-1140a).
+            throw Error($"XTDE1140: The regex attribute of xsl:analyze-string is not a valid regular expression: {ex.Message}");
+        }
 
         // First pass: collect all matches to compute total substring count for position()/last()
         var matches = new List<System.Text.RegularExpressions.Match>();

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Output.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Output.cs
@@ -81,7 +81,17 @@ public sealed partial class StylesheetParser
         if (formatAttr != null && formatAvt != null
             && formatAvt.Parts.Count == 1 && formatAvt.Parts[0] is AvtLiteral)
         {
-            resolvedFormat = ParseQName(formatAttr.Value.Trim(), element);
+            // Not a QName, or a prefix with no binding: XTDE1460 (which may be raised
+            // statically), not XTSE0280 (error-1460c).
+            try
+            {
+                resolvedFormat = ParseQName(formatAttr.Value.Trim(), element);
+            }
+            catch (XsltException ex) when (ex.Message.StartsWith("XTSE0280", StringComparison.Ordinal)
+                || ex.Message.StartsWith("XTSE0020", StringComparison.Ordinal))
+            {
+                throw new XsltException($"XTDE1460: The format attribute of xsl:result-document ('{formatAttr.Value}') is not a valid EQName", location);
+            }
         }
 
         var cdataSectionElementsAvt = cdataSectionElementsAttr != null

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Templates.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Templates.cs
@@ -85,11 +85,11 @@ public sealed partial class StylesheetParser
 
         // XTSE0010: name is REQUIRED on xsl:call-template — there is nothing to call without it.
         // Was dereferenced with `!`, giving a NullReferenceException (error-0010ad).
-        var name = ParseQName(
-            element.Attribute("name")?.Value
-                ?? throw new XsltException("XTSE0010: xsl:call-template requires a 'name' attribute",
-                    location),
-            element);
+        var nameValue = element.Attribute("name")?.Value
+            ?? throw new XsltException("XTSE0010: xsl:call-template requires a 'name' attribute", location);
+        // name="x/y" is not a QName: XTSE0020, not "template not found" (error-0020f).
+        ValidateQNameValue(nameValue, "name", location);
+        var name = ParseQName(nameValue, element);
 
         var withParams = new List<XsltWithParam>();
         foreach (var child in element.Elements())

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
@@ -616,7 +616,9 @@ public sealed partial class StylesheetParser
                 // XTSE0550: validate mode token is a valid QName (no #, !, etc.)
                 if (mode.StartsWith('#'))
                     throw new XsltException($"XTSE0550: Invalid mode token '{mode}' in mode list of xsl:template", GetSourceLocation(element));
-                ValidateQNameValue(mode, "mode", GetSourceLocation(element));
+                // An invalid token in the list is XTSE0550 — the list's own rule — not the
+                // generic XTSE0020 (error-0550a/e/f).
+                ValidateQNameValue(mode, "mode", GetSourceLocation(element), "XTSE0550");
                 modes.Add(ParseQName(mode, element));
             }
             // XTSE0550: #all must not appear with other modes
@@ -1270,7 +1272,7 @@ public sealed partial class StylesheetParser
     /// Validates that a QName attribute value is syntactically valid (XTSE0020).
     /// Rejects AVT syntax ({...}) and invalid QName characters.
     /// </summary>
-    private static void ValidateQNameValue(string value, string attrName, SourceLocation? location)
+    private static void ValidateQNameValue(string value, string attrName, SourceLocation? location, string code = "XTSE0020")
     {
         value = value.Trim();
         // EQName syntax Q{uri}local is always valid — skip all checks
@@ -1278,13 +1280,13 @@ public sealed partial class StylesheetParser
             return;
         // AVT syntax {..} is not permitted in QName attributes
         if (value.Contains('{', StringComparison.Ordinal) || value.Contains('}', StringComparison.Ordinal))
-            throw new XsltException($"XTSE0020: Attribute value templates are not permitted in the '{attrName}' attribute", location);
+            throw new XsltException($"{code}: Attribute value templates are not permitted in the '{attrName}' attribute", location);
         if (value.Length > 0 && char.IsAsciiDigit(value[0]))
-            throw new XsltException($"XTSE0020: Invalid QName '{value}' for '{attrName}' attribute: names must not start with a digit", location);
+            throw new XsltException($"{code}: Invalid QName '{value}' for '{attrName}' attribute: names must not start with a digit", location);
         if (value.Contains('/', StringComparison.Ordinal))
-            throw new XsltException($"XTSE0020: Invalid QName '{value}' for '{attrName}' attribute", location);
+            throw new XsltException($"{code}: Invalid QName '{value}' for '{attrName}' attribute", location);
         if (value.Contains("::", StringComparison.Ordinal))
-            throw new XsltException($"XTSE0020: Invalid QName '{value}' for '{attrName}' attribute", location);
+            throw new XsltException($"{code}: Invalid QName '{value}' for '{attrName}' attribute", location);
         // Check for common invalid NCName characters
         foreach (var ch in value)
         {
@@ -1292,7 +1294,7 @@ public sealed partial class StylesheetParser
                 ch == '(' || ch == ')' || ch == '[' || ch == ']' || ch == ',' ||
                 ch == '=' || ch == '+' || ch == '<' || ch == '>' || ch == '?')
             {
-                throw new XsltException($"XTSE0020: Invalid QName '{value}' for '{attrName}' attribute: character '{ch}' is not allowed", location);
+                throw new XsltException($"{code}: Invalid QName '{value}' for '{attrName}' attribute: character '{ch}' is not allowed", location);
             }
         }
     }

--- a/src/PhoenixmlDb.Xslt/Engine/XsltKeyFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltKeyFunction.cs
@@ -93,7 +93,21 @@ internal sealed class XsltKeyFunction : PhoenixmlDb.XQuery.Ast.XQueryFunction
             // Guard: only when context is non-null (EvaluateKeyPattern passes null context)
             if (context != null)
             {
-                if (XQueryFocus.ItemOrNull(context) is XdmNode xqNode
+                object? focus;
+                try
+                {
+                    focus = XQueryFocus.ItemOrNull(context);
+                }
+                catch (PhoenixmlDb.XQuery.Execution.XQueryRuntimeException ex) when (ex.ErrorCode == "XPDY0002")
+                {
+                    // Absent focus — in a function body, say. The two-argument form needs a
+                    // context node, so that is XTDE1270 (error-1270a); the three-argument form
+                    // does not use the focus at all.
+                    if (arguments.Count <= 2)
+                        throw new XsltException("XTDE1270: The key() function with two arguments requires a context node, but the focus is absent");
+                    focus = null;
+                }
+                if (focus is XdmNode xqNode
                     && _context.FindDocumentForNode(xqNode) != null)
                     contextItem = xqNode;
             }
@@ -393,8 +407,11 @@ internal sealed class XsltKeyFunction : PhoenixmlDb.XQuery.Ast.XQueryFunction
             // resolve against the in-scope namespaces of the element containing the key() call,
             // which needs the expression's static context at runtime; this is narrower but
             // sound where it applies, and it refuses to guess when it cannot tell.
+            // Only keys in SOME namespace: key('my:k') must not find a key named plain 'k'
+            // (error-1260e) — a prefixed name never expands to no namespace.
             var byLocalName = _context._stylesheet.Keys
-                .Where(kv => string.Equals(kv.Key.LocalName, localName, StringComparison.Ordinal))
+                .Where(kv => kv.Key.Namespace != NamespaceId.None
+                    && string.Equals(kv.Key.LocalName, localName, StringComparison.Ordinal))
                 .ToList();
             if (byLocalName.Count == 1)
                 return FilterToCallingPackage(byLocalName[0].Value);

--- a/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
@@ -353,6 +353,16 @@ public sealed class XsltTransformEngine
             // Only pass explicitly-set template params; global InitialParameters are set as
             // stylesheet-level variables separately and should NOT be passed as with-params.
             var withParams = BuildInitialTemplateWithParams(options);
+            // A required parameter the invocation does not supply is the dynamic XTDE0700 here:
+            // there is no xsl:call-template for the static XTSE0690 to point at (error-0700b).
+            if (context.FindNamedTemplate(initialTemplate.Value) is { } initial)
+            {
+                foreach (var p in initial.Parameters)
+                {
+                    if (p.Required && !p.Tunnel && !withParams.Any(w => !w.Tunnel && w.Name.Equals(p.Name)))
+                        throw new XsltException($"XTDE0700: Required parameter ${p.Name.LocalName} of the initial template is not supplied");
+                }
+            }
             // When calling an initial template with no source document, the context item
             // should be absent per XSLT 3.0 §2.3
             if (!options.HasSourceDocument)

--- a/tests/PhoenixmlDb.Xslt.Tests/MiscErrorCodeTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/MiscErrorCodeTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Error codes for a batch of W3C misc/error cases, each of which reported a neighbouring code (or
+/// none): the code says which rule was broken, so a wrong one sends the reader to the wrong rule.
+/// </summary>
+public sealed class MiscErrorCodeTests
+{
+    private static async Task<string> RunAsync(string stylesheet, string source = "<doc/>")
+    {
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(stylesheet);
+        return (await t.TransformAsync(source)).Trim();
+    }
+
+    private static string Wrap(string declarations, string body = "") => $"""
+        <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my">
+          <xsl:output method="text"/>
+          {declarations}
+          <xsl:template match="/">{body}</xsl:template>
+        </xsl:stylesheet>
+        """;
+
+    private static async Task AssertErrorAsync(string stylesheet, string code, string source = "<doc/>")
+    {
+        var act = () => RunAsync(stylesheet, source);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain(code);
+    }
+
+    /// <summary>A name that is not a QName is XTSE0020, not "template not found" (error-0020f).</summary>
+    [Fact]
+    public Task CallTemplate_WithANameThatIsNotAQName_IsXTSE0020()
+        => AssertErrorAsync(Wrap("""<xsl:template name="x"/>""", """<xsl:call-template name="x/y"/>"""), "XTSE0020");
+
+    /// <summary>An invalid token in a mode list is the list's own error, XTSE0550 (error-0550a/e/f).</summary>
+    [Theory]
+    [InlineData("name!1223")]
+    [InlineData("a b c#")]
+    public Task Template_WithAnInvalidModeToken_IsXTSE0550(string mode)
+        => AssertErrorAsync(Wrap($"""<xsl:template match="p" mode="{mode}"/>"""), "XTSE0550");
+
+    /// <summary>
+    /// A required parameter the invocation cannot supply is the dynamic XTDE0700: there is no
+    /// xsl:call-template for the static XTSE0690 to point at (error-0700b).
+    /// </summary>
+    [Fact]
+    public async Task AnInitialTemplate_WithARequiredParameter_IsXTDE0700()
+    {
+        var ss = """
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="text"/>
+              <xsl:template name="xsl:initial-template"><xsl:param name="y" required="yes"/><xsl:value-of select="$y"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        var act = () => t.TransformAsync((string?)null);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTDE0700");
+    }
+
+    /// <summary>A regex the engine cannot compile escaped with no error code at all (error-1140a).</summary>
+    [Fact]
+    public Task AnalyzeString_WithAnInvalidRegex_IsXTDE1140()
+        => AssertErrorAsync(Wrap("", """<xsl:analyze-string select="'bananas'" regex="[A-Z"><xsl:matching-substring/></xsl:analyze-string>"""), "XTDE1140");
+
+    /// <summary>A format that is not a QName is XTDE1460, not the generic namespace error (error-1460c).</summary>
+    [Fact]
+    public Task ResultDocument_WithAFormatThatIsNotAQName_IsXTDE1460()
+        => AssertErrorAsync(Wrap("""<xsl:output name="xyz" method="xml"/>""", """<xsl:result-document format="not:a:qname"><apple/></xsl:result-document>"""), "XTDE1460");
+
+    /// <summary>
+    /// A prefixed key name never expands to no namespace, so key('my:k') must not find a key
+    /// declared as plain 'k' — it is XTDE1260 (error-1260e).
+    /// </summary>
+    [Fact]
+    public Task Key_WithAPrefixedNameOfAnUnprefixedKey_IsXTDE1260()
+        => AssertErrorAsync(Wrap("""<xsl:key name="k" match="*" use="17"/>""", """<xsl:value-of select="key('my:k', 'abc')"/>"""), "XTDE1260");
+
+    /// <summary>key() with two arguments needs a context node; in a function body there is none (error-1270a).</summary>
+    [Fact]
+    public Task Key_WithTwoArgumentsAndNoFocus_IsXTDE1270()
+        => AssertErrorAsync(Wrap(
+            """<xsl:key name="k" match="*" use="'pqr'"/><xsl:function name="my:f"><xsl:sequence select="key('k', 'abc')"/></xsl:function>""",
+            """<xsl:value-of select="my:f()"/>"""), "XTDE1270");
+
+    /// <summary>A key that does resolve still answers, and a namespaced key still resolves by prefix.</summary>
+    [Fact]
+    public async Task KeysThatResolve_StillAnswer()
+        => (await RunAsync(Wrap(
+            """<xsl:key name="k" match="a" use="@id"/><xsl:key name="my:nk" match="b" use="@id"/>""",
+            """<xsl:value-of select="count(key('k', '1')), count(key('my:nk', '2'))"/>"""),
+            """<doc><a id="1"/><b id="2"/></doc>""")).Should().Be("1 1");
+}


### PR DESCRIPTION
Seven places reported a neighbouring error code, or none at all. The code is how a user finds the rule they broke, so a wrong one sends them to the wrong rule.

| Case | Was | Now |
|---|---|---|
| `xsl:call-template name="x/y"` | XTSE0650 "template not found" | XTSE0020 |
| invalid token in a template's `mode` list | XTSE0020 | XTSE0550 |
| required parameter of the initial template | XTSE0690 | XTDE0700 |
| regex .NET rejects in `xsl:analyze-string` | bare `ArgumentException`, no code | XTDE1140 |
| `xsl:result-document format` that is not a QName | XTSE0280 | XTDE1460 |
| `key('my:k')` finding a key declared plain `k` | returned that key's nodes | XTDE1260 |
| `key()` (2-arg) with an absent focus | XPDY0002 | XTDE1270 |

Two deserve a word:

- **`key('my:k')`** — the by-local-name fallback (added for XSpec, where a prefix is bound to different URIs in different modules) also matched keys in *no* namespace. A prefixed name never expands to no namespace, so the fallback is now limited to keys that are in some namespace.
- **`key()` with an absent focus** — `XQueryFocus.ItemOrNull` propagates XPDY0002 deliberately (see its comment). This catches it only inside `key()`: the 2-argument form needs a context node, which is exactly XTDE1270, and the 3-argument form does not use the focus at all.

**Tests:** `MiscErrorCodeTests`, 9 cases including a control that keys which do resolve still answer. 8 of the 9 fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): +14, zero per-set losses — the 10 targeted `misc/error` cases plus initial-template-902, call-template-0401a, key-080 and param-0116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn