### PR TITLE
Four more error codes, and duration merge keys compare by length

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
@@ -1599,7 +1599,9 @@ internal sealed partial class DefaultXsltExecutionContext
         }
         catch (Exception ex)
         {
-            throw new XsltException($"XTDE3150: Dynamic XPath expression is not valid: {ex.Message}", instruction.Location);
+            // A static error while analysing the xpath string is XTDE3160 (XSLT 3.0 §19.4);
+            // XTDE3150 is a different rule (error-3160a).
+            throw new XsltException($"XTDE3160: Dynamic XPath expression is not valid: {ex.Message}", instruction.Location);
         }
 
         // Determine namespace bindings for the dynamic expression.
@@ -1640,6 +1642,15 @@ internal sealed partial class DefaultXsltExecutionContext
         if (instruction.ContextItem != null)
         {
             contextItem = await EvaluateAsync(instruction.ContextItem).ConfigureAwait(false);
+            // The context item is one item or none. A longer sequence was pushed whole, and the
+            // dynamic expression's first axis step then failed on "an item of type Object[]"
+            // instead of reporting the type error (error-3210a).
+            if (contextItem is object?[] contextItems)
+            {
+                if (contextItems.Length > 1)
+                    throw new XsltException("XTTE3210: The context-item attribute of xsl:evaluate must evaluate to a single item", instruction.Location);
+                contextItem = contextItems.Length == 1 ? contextItems[0] : null;
+            }
         }
 
         // Evaluate base-uri AVT if specified

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Grouping.cs
@@ -719,6 +719,15 @@ internal sealed partial class DefaultXsltExecutionContext
             return dtoa.CompareTo(dtob);
         if (a is decimal da && b is decimal db)
             return da.CompareTo(db);
+        // Durations: two of the same kind compare by length. They fell through to the string
+        // comparison below, which orders "P10D" before "P2D" and reported the source as
+        // unsorted (XTDE2220) before the cross-source type error could be raised (error-2230a).
+        if (a is DayTimeDuration dta && b is DayTimeDuration dtb)
+            return dta.CompareTo(dtb);
+        if (a is YearMonthDuration yma && b is YearMonthDuration ymb)
+            return yma.CompareTo(ymb);
+        if (a is TimeSpan tsa && b is TimeSpan tsb)
+            return tsa.CompareTo(tsb);
 
         // XTTE2230: Check for incomparable types before falling back to string
         if (IsMergeKeyNumeric(a) != IsMergeKeyNumeric(b) && a is not string && b is not string)

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
@@ -2170,6 +2170,13 @@ public sealed partial class StylesheetParser
         if (streamabilityAttr != null)
         {
             var streamability = streamabilityAttr.Value.Trim();
+            // XTSE3155: a streamability other than "unclassified" classifies how the function
+            // consumes its FIRST argument, so a function with no xsl:param cannot carry one.
+            // It was not checked at all (error-3155a, su-shallow-descent-901).
+            if (streamability is not ("unclassified" or "") && parameters.Count == 0)
+                throw new XsltException(
+                    $"XTSE3155: xsl:function '{name.LocalName}' has no xsl:param, so its streamability must be 'unclassified', not '{streamability}'",
+                    location);
             if (streamability is "absorbing" or "filter" or "inspection" or "shallow-descent"
                 or "deep-descent" or "ascent")
             {

--- a/tests/PhoenixmlDb.Xslt.Tests/MiscErrorCodeTests2.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/MiscErrorCodeTests2.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A second batch of error codes that named a different rule than the one broken, plus the
+/// duration ordering defect behind one of them.
+/// </summary>
+public sealed class MiscErrorCodeTests2
+{
+    private static async Task<string> RunAsync(string body, string declarations = "", string source = "<doc/>")
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:f="urn:f" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              {declarations}
+              <xsl:template match="/">{body}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync(source)).Trim();
+    }
+
+    private static async Task AssertErrorAsync(string body, string code, string declarations = "")
+    {
+        var act = () => RunAsync(body, declarations);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain(code);
+    }
+
+    /// <summary>An xpath string that does not parse is XTDE3160, not XTDE3150 (error-3160a).</summary>
+    [Fact]
+    public Task Evaluate_WithAnXPathThatDoesNotParse_IsXTDE3160()
+        => AssertErrorAsync("""<xsl:evaluate xpath="concat(current-date(), '/')"/>""", "XTDE3160");
+
+    /// <summary>
+    /// The context item is one item or none. A longer sequence was pushed whole and the dynamic
+    /// expression's first axis step failed on "an item of type Object[]" (error-3210a).
+    /// </summary>
+    [Fact]
+    public Task Evaluate_WithASequenceContextItem_IsXTTE3210()
+        => AssertErrorAsync(
+            """<xsl:variable name="v" as="element()*"><x/><y/></xsl:variable><xsl:evaluate xpath="'count(//x)'" context-item="$v"/>""",
+            "XTTE3210");
+
+    [Fact]
+    public async Task Evaluate_WithASingleContextItem_StillEvaluates()
+        => (await RunAsync("""<xsl:evaluate xpath="'count(//x)'" context-item="/"/>""", source: "<doc><x/><x/></doc>"))
+            .Should().Be("2");
+
+    /// <summary>
+    /// A streamability other than unclassified classifies how the function consumes its first
+    /// argument, so a function with no xsl:param cannot carry one (error-3155a).
+    /// </summary>
+    [Fact]
+    public Task Function_WithNoParam_AndAStreamability_IsXTSE3155()
+        => AssertErrorAsync("", "XTSE3155",
+            """<xsl:function name="f:x" streamability="absorbing"><xsl:sequence select="22"/></xsl:function>""");
+
+    [Fact]
+    public async Task Function_WithAParam_KeepsItsStreamability()
+        => (await RunAsync("""<xsl:value-of select="f:x(2)"/>""",
+            """<xsl:function name="f:x" streamability="unclassified"><xsl:param name="n"/><xsl:sequence select="$n * 11"/></xsl:function>"""))
+            .Should().Be("22");
+
+    /// <summary>
+    /// Durations of the same kind compare by length. They fell through to a string comparison,
+    /// which orders P10D before P2D — so a sorted merge source looked unsorted (XTDE2220) and the
+    /// real cross-source type error was never reached (error-2230a).
+    /// </summary>
+    [Fact]
+    public Task Merge_WithIncomparableKeyTypes_IsXTTE2230()
+        => AssertErrorAsync("""
+            <xsl:merge>
+              <xsl:merge-source name="a" select="1 to 50"><xsl:merge-key select="."/></xsl:merge-source>
+              <xsl:merge-source name="b" select="1 to 50"><xsl:merge-key select="xs:dayTimeDuration('P1D') * ."/></xsl:merge-source>
+              <xsl:merge-action>22</xsl:merge-action>
+            </xsl:merge>
+            """, "XTTE2230");
+
+    [Theory]
+    [InlineData("xs:dayTimeDuration('P1D') * .", "P1D P2D P10D")]
+    [InlineData("xs:yearMonthDuration('P1M') * .", "P1M P2M P10M")]
+    public async Task DurationMergeKeys_AreOrderedByLength(string key, string expected)
+        => (await RunAsync($"""
+            <xsl:merge>
+              <xsl:merge-source select="(1, 2, 10)"><xsl:merge-key select="{key}"/></xsl:merge-source>
+              <xsl:merge-action><xsl:value-of select="current-merge-key()"/><xsl:text> </xsl:text></xsl:merge-action>
+            </xsl:merge>
+            """)).Should().Be(expected);
+}


### PR DESCRIPTION
A second batch of codes that named a different rule than the one broken, plus the ordering defect behind one of them.

| Case | Was | Now |
|---|---|---|
| `xsl:evaluate` xpath that does not parse | XTDE3150 | XTDE3160 |
| `xsl:evaluate context-item` with several items | axis-step failure on `Object[]` | XTTE3210 |
| `xsl:function` with no `xsl:param` and a streamability | not checked | XTSE3155 |
| merge keys of two incomparable types | XTDE2220 "not correctly sorted" | XTTE2230 |

The last one is a real ordering defect, not just a code. Two `xs:dayTimeDuration` keys had no typed comparison, so they fell through to the string comparison: `P10D` sorts before `P2D`, the source was reported unsorted, and the cross-source type error was never reached. Same-kind durations (dayTime, yearMonth, TimeSpan) now compare by length.

**Tests:** `MiscErrorCodeTests2`, 8 cases, including controls that a single context item still evaluates and a function with a param keeps its streamability, and that duration keys order P1D, P2D, P10D. 6 of the 8 fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): +6, zero per-set losses — the four targets plus evaluate-026 and su-shallow-descent-901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn