### PR TITLE
Invoking an abstract component is XTDE3052, not "not found"

### DIFF
--- a/src/PhoenixmlDb.Xslt/Ast/XsltStylesheet.cs
+++ b/src/PhoenixmlDb.Xslt/Ast/XsltStylesheet.cs
@@ -95,6 +95,26 @@ public sealed class XsltStylesheet
     public HashSet<QName> AbstractVariableNames { get; init; } = new();
 
     /// <summary>
+    /// Named templates from used packages that remain abstract (or were hidden by xsl:accept),
+    /// so they exist as components but have no body to run. Calling one is XTDE3052; they are
+    /// not merged into <see cref="NamedTemplates"/>, where they would be callable.
+    /// </summary>
+    public HashSet<QName> AbstractTemplateNames { get; init; } = new();
+
+    /// <summary>
+    /// Functions from used packages that remain abstract, keyed as <see cref="Functions"/> is.
+    /// Calling one is XTDE3052. A stub is registered for each at function-library construction,
+    /// but only where no concrete function of that name and arity exists.
+    /// </summary>
+    public HashSet<(QName Name, int Arity)> AbstractFunctionKeys { get; init; } = new();
+
+    /// <summary>
+    /// True when an xsl:accept in this package accepts a component with visibility="abstract".
+    /// That makes this package abstract in turn, so it cannot be executed: XTSE3080.
+    /// </summary>
+    public bool HasAcceptedAbstractComponent { get; set; }
+
+    /// <summary>
     /// Package-local global variables that could not take the principal QName-keyed slot
     /// because a same-named global from another package already claimed it. Each is stamped
     /// with its owning package (<see cref="XsltVariable.PackageStylesheet"/>) and resolved

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
@@ -1117,6 +1117,14 @@ internal sealed partial class DefaultXsltExecutionContext
                 // transform engine checks that before it gets here.)
                 // Name the namespace too. The old message quoted only the local part, which is
                 // exactly the information that does not help when the namespace is the problem.
+                // A call from INSIDE the package that declares the template, where the name is
+                // visible but abstract — no implementation to run — is the dynamic XTDE3052
+                // (accept-045b/c, accept-905..908). From the USING package the same name is
+                // simply not visible, which stays the static XTSE0650 (error-3052a).
+                var callingPackage = XsltFormatNumberEngine.GetCurrentPackageStylesheet(this);
+                if (callingPackage != null && !ReferenceEquals(callingPackage, _stylesheet)
+                    && callingPackage.AbstractTemplateNames.Contains(name))
+                    throw Error($"XTDE3052: Named template '{name.LocalName}' is abstract and has no concrete implementation");
                 var uri = QNameNamespaces.UriOf(name, ResolveViaStylesheet);
                 throw Error(uri.Length > 0
                     ? $"XTSE0650: Named template 'Q{{{uri}}}{name.LocalName}' not found"

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -840,6 +840,15 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
                 lib.RegisterPrefix(xsltFunc.Name.Prefix, xsltFunc.Name.Namespace);
         }
 
+        // An abstract function exists as a component but has no body. Registering nothing left
+        // the call site reporting "function not found" — a name nothing declares — where the
+        // answer is the dynamic XTDE3052 (accept-041b/c, accept-901..904).
+        foreach (var key in stylesheet.AbstractFunctionKeys)
+        {
+            if (!stylesheet.Functions.ContainsKey(key))
+                lib.Register(new XsltAbstractFunctionAdapter(key.Name, key.Arity));
+        }
+
         // Register xsl:original function for package overrides — resolved dynamically
         // at runtime via _currentXsltFunctionStack
         lib.Register(new XsltOriginalFunctionAdapter(this));

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
@@ -1031,8 +1031,29 @@ public sealed partial class StylesheetParser
                 acceptElements.Add(child);
             }
         }
+        // xsl:accept rewrites each component's visibility, so record what the used package
+        // DECLARED abstract first. A component accepted as hidden is still abstract — it has no
+        // implementation — and calling it is XTDE3052, not "not found" (accept-901/905, 041b/c).
+        foreach (var (templateName, packageTemplate) in packageStylesheet.NamedTemplates)
+        {
+            if (packageTemplate.Visibility is Visibility.Abstract)
+                packageStylesheet.AbstractTemplateNames.Add(templateName);
+        }
+        foreach (var (functionKey, packageFunction) in packageStylesheet.Functions)
+        {
+            if (packageFunction.Visibility is Visibility.Abstract)
+                packageStylesheet.AbstractFunctionKeys.Add(functionKey);
+        }
         if (acceptElements.Count > 0)
             ApplyAcceptVisibilities(acceptElements, packageStylesheet);
+        // Accepting a component AS abstract makes the using package abstract in turn, so it
+        // cannot be executed: XTSE3080 (accept-904/908/912/914). Accepting the same component as
+        // hidden does not — it stays executable, and calling the component is XTDE3052
+        // (accept-901/905). What the used package happens to declare abstract is not the test:
+        // a package is free to use one whose internals are abstract, as long as it does not
+        // accept them as abstract itself.
+        if (acceptElements.Any(a => a.Attribute("visibility")?.Value.Trim() == "abstract"))
+            stylesheet.HasAcceptedAbstractComponent = true;
 
         // XTSE3050 (cross-package): each xsl:use-package is a distinct instance of the used
         // package, so a component it contributes as a visible (accepted, not hidden) component

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Grouping.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Grouping.cs
@@ -57,6 +57,14 @@ public sealed partial class StylesheetParser
         {
             if (template.Visibility is not (Visibility.Abstract or Visibility.Hidden))
                 target.NamedTemplates.TryAdd(name, template);
+            else if (template.Visibility is Visibility.Abstract)
+                target.AbstractTemplateNames.Add(name);
+        }
+        foreach (var name in package.AbstractTemplateNames)
+            target.AbstractTemplateNames.Add(name);
+        foreach (var key in package.AbstractFunctionKeys)
+            target.AbstractFunctionKeys.Add(key);
+        {
         }
 
         // Template rules: add public/final and overrides
@@ -72,6 +80,8 @@ public sealed partial class StylesheetParser
         {
             if (func.Visibility is not (Visibility.Abstract or Visibility.Hidden))
                 target.Functions.TryAdd(key, func);
+            else if (func.Visibility is Visibility.Abstract)
+                target.AbstractFunctionKeys.Add(key);
         }
 
         // Variables: merge all except abstract (private variables may be referenced

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
@@ -369,6 +369,9 @@ public sealed partial class StylesheetParser
         // Abstract components are only valid in library packages intended for use-package overriding.
         if (!stylesheet.IsPackage) return;
 
+        if (stylesheet.HasAcceptedAbstractComponent)
+            throw new XsltException("XTSE3080: Top-level package accepts a component with visibility=\"abstract\"");
+
         foreach (var template in stylesheet.Templates)
         {
             if (template.Visibility == Visibility.Abstract)
@@ -447,7 +450,10 @@ public sealed partial class StylesheetParser
         {
             foreach (var usedName in useAttrSets)
             {
-                if (!stylesheet.AttributeSets.ContainsKey(usedName))
+                // An abstract set from a used package is declared but has no content: leave it
+                // to the runtime XTDE3052 at the point of use (accept-909..913).
+                if (!stylesheet.AttributeSets.ContainsKey(usedName)
+                    && !stylesheet.AbstractAttributeSetNames.Contains(usedName))
                     throw new XsltException($"XTSE0710: Attribute set '{usedName}' is not defined");
             }
         }

--- a/src/PhoenixmlDb.Xslt/Engine/XsltAbstractFunctionAdapter.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAbstractFunctionAdapter.cs
@@ -1,0 +1,37 @@
+using PhoenixmlDb.Core;
+using PhoenixmlDb.XQuery.Ast;
+
+namespace PhoenixmlDb.Xslt.Engine;
+
+/// <summary>
+/// Stands in for a function of a used package that remains abstract (declared
+/// visibility="abstract" and never overridden with a concrete implementation). The component
+/// exists — the name is declared — but there is no body to run, so calling it is XTDE3052.
+/// Without the stub the call reported "function not found", which is the answer for a name
+/// nothing declares at all.
+/// </summary>
+internal sealed class XsltAbstractFunctionAdapter : XQueryFunction
+{
+    private readonly int _arity;
+
+    public XsltAbstractFunctionAdapter(QName name, int arity)
+    {
+        Name = name;
+        _arity = arity;
+        Parameters = Enumerable.Range(0, arity)
+            .Select(i => new FunctionParameterDef
+            {
+                Name = new QName(NamespaceId.None, $"arg{i + 1}"),
+                Type = XdmSequenceType.ZeroOrMoreItems,
+            })
+            .ToList();
+    }
+
+    public override QName Name { get; }
+    public override XdmSequenceType ReturnType => XdmSequenceType.ZeroOrMoreItems;
+    public override IReadOnlyList<FunctionParameterDef> Parameters { get; }
+
+    public override ValueTask<object?> InvokeAsync(IReadOnlyList<object?> arguments, PhoenixmlDb.XQuery.Ast.ExecutionContext context)
+        => throw new XsltException(
+            $"XTDE3052: Function {Name.LocalName}#{_arity} is abstract and has no concrete implementation");
+}

--- a/tests/PhoenixmlDb.Xslt.Tests/AbstractComponentTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/AbstractComponentTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// An abstract component of a used package exists — the name is declared — but has no body to
+/// run, so invoking it is XTDE3052. Abstract functions and named templates were not merged at
+/// all, so the call reported "not found", which is the answer for a name nothing declares.
+/// Accepting a component AS abstract makes the using package abstract in turn: it cannot be
+/// executed (XTSE3080). Mirrors W3C decl/accept accept-041b, 045b, 901..914.
+/// </summary>
+public sealed class AbstractComponentTests : IDisposable
+{
+    private readonly string _dir;
+
+    public AbstractComponentTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "pxabstract-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// A library package with an abstract function and an abstract named template, each reached
+    /// through a public proxy — so the call comes from inside the package that declares them.
+    /// </summary>
+    private const string Library = """
+        <xsl:package name="urn:lib" package-version="1.0.0" version="3.0"
+          xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:c="urn:c" exclude-result-prefixes="#all">
+          <xsl:function name="c:abstract" visibility="abstract"><xsl:param name="p"/></xsl:function>
+          <xsl:template name="t-abstract" visibility="abstract"/>
+          <xsl:template name="call-function" visibility="public"><xsl:value-of select="c:abstract(1)"/></xsl:template>
+          <xsl:template name="call-template" visibility="public"><xsl:call-template name="t-abstract"/></xsl:template>
+        </xsl:package>
+        """;
+
+    private async Task<string> RunAsync(string principal, string initialTemplate = "main")
+    {
+        var libPath = Path.Combine(_dir, "lib.xsl");
+        await File.WriteAllTextAsync(libPath, Library).ConfigureAwait(false);
+        var catalog = new Dictionary<string, List<(string? Version, string FilePath)>>
+        {
+            ["urn:lib"] = new() { ("1.0.0", libPath) },
+        };
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(principal, new Uri(Path.Combine(_dir, "principal.xsl")), null, catalog);
+        t.SetInitialTemplate(initialTemplate);
+        return await t.TransformAsync("<in/>");
+    }
+
+    private static string Principal(string accepts, string body) => $"""
+        <xsl:package name="urn:main" package-version="1.0.0" version="3.0"
+          xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="#all">
+          <xsl:output method="text"/>
+          <xsl:use-package name="urn:lib" package-version="1.0.0">{accepts}</xsl:use-package>
+          <xsl:template name="main" visibility="public">{body}</xsl:template>
+        </xsl:package>
+        """;
+
+    [Theory]
+    [InlineData("call-function")]
+    [InlineData("call-template")]
+    public async Task InvokingAnAbstractComponent_FromItsOwnPackage_IsXTDE3052(string proxy)
+    {
+        var act = () => RunAsync(Principal("", $"""<xsl:call-template name="{proxy}"/>"""));
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTDE3052");
+    }
+
+    /// <summary>
+    /// Accepting a component as hidden leaves the package executable — the component is simply
+    /// not visible here, so calling that name stays the static XTSE0650 (W3C error-3052a).
+    /// </summary>
+    [Fact]
+    public async Task CallingAHiddenName_FromTheUsingPackage_IsStillXTSE0650()
+    {
+        var act = () => RunAsync(Principal(
+            """<xsl:accept component="template" names="t-abstract" visibility="hidden"/>""",
+            """<xsl:call-template name="t-abstract"/>"""));
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTSE0650");
+    }
+
+    [Fact]
+    public async Task AcceptingAComponentAsAbstract_MakesThePackageNonExecutable_XTSE3080()
+    {
+        var act = () => RunAsync(Principal(
+            """<xsl:accept component="*" names="*" visibility="abstract"/>""", "ok"));
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XTSE3080");
+    }
+
+    /// <summary>A package that merely uses a library with abstract internals still runs.</summary>
+    [Fact]
+    public async Task APackageUsingAbstractInternals_StillRuns()
+        => (await RunAsync(Principal("", "ok"))).Trim().Should().Be("ok");
+}


### PR DESCRIPTION
An abstract component of a used package exists — the name is declared — but has no body to run. Invoking one is XTDE3052. Abstract functions and named templates were dropped at merge time instead, so the call reported "function not found" or XTSE0650, which is the answer for a name nothing declares at all. (Variables and attribute-sets already followed the XTDE3052 pattern; this extends it to the other two kinds and fixes where the attribute-set path was pre-empted.)

- **Merge:** abstract template names and function keys are recorded, and `XsltAbstractFunctionAdapter` stands in for each abstract function — registered only where no concrete function of that name and arity exists, so an override always wins.
- **Which code:** `xsl:accept` rewrites a component's visibility, so what the used package *declared* abstract is captured first. A call from inside the declaring package, where the name is visible but abstract, is XTDE3052 (accept-045b: a public proxy calls its package's own abstract template). The same name called from the using package, which accepted it as hidden, is not visible there and stays the static XTSE0650 (error-3052a).
- **Attribute sets:** a reference to an abstract set no longer trips the static XTSE0710 "not defined" check, so the runtime XTDE3052 at the point of use is reached.
- **XTSE3080:** accepting a component *as* abstract (`visibility="abstract"`) makes the using package abstract in turn, so it cannot be executed. Merely using a library whose internals are abstract does not.

**Tests:** `AbstractComponentTests`, 5 cases over a two-package catalog fixture, including controls that a hidden name stays XTSE0650 and that a package using abstract internals still runs. 3 of the 5 fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): +21, zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn