### PR TITLE
Three more error codes: xsl:key content, streamable attribute sets, document()

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
@@ -2256,6 +2256,17 @@ public sealed partial class StylesheetParser
         if (collationAttr != null)
             ValidateCollationList(collationAttr.Value, GetSourceLocation(element), "XTSE1210");
 
+        // XTSE0010: the content of xsl:key is a sequence constructor, so a DECLARATION there is
+        // not allowed content at all. It was reported as XTSE1205 "both a use attribute and
+        // content", which describes a different mistake (key-092).
+        foreach (var keyChild in element.Elements())
+        {
+            if (keyChild.Name.Namespace == XsltNs && IsDeclarationOnlyElement(keyChild.Name.LocalName))
+                throw new XsltException(
+                    $"XTSE0010: xsl:{keyChild.Name.LocalName} is not allowed as content of xsl:key",
+                    GetSourceLocation(keyChild));
+        }
+
         // XTSE1205: xsl:key must have either use attribute or non-empty content, not both
         var hasContent = element.Nodes().Any(n => n is XElement || (n is XText t && !string.IsNullOrWhiteSpace(t.Value)));
         if (useAttr != null && hasContent)

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.NodeIO.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.NodeIO.cs
@@ -65,6 +65,7 @@ public sealed partial class StylesheetParser
         // same-precedence conflicts that are overridden by higher-precedence declarations.
         ValidateDecimalFormats(stylesheet);
         ValidateAttributeSetReferences(stylesheet);
+        ValidateStreamableAttributeSets(stylesheet);
         if (!isLibraryPackage)
             ValidateNoAbstractComponents(stylesheet);
         ValidateOutputCharacterMapReferences(stylesheet);

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.cs
@@ -426,6 +426,39 @@ public sealed partial class StylesheetParser
     }
 
 
+    /// <summary>
+    /// True for XSLT elements that may only appear as a declaration (a child of xsl:stylesheet,
+    /// xsl:package or xsl:override), never inside a sequence constructor.
+    /// </summary>
+    private static bool IsDeclarationOnlyElement(string localName) => localName is
+        "stylesheet" or "transform" or "package" or "template" or "function" or "key" or
+        "import" or "include" or "import-schema" or "decimal-format" or "character-map" or
+        "output" or "attribute-set" or "accumulator" or "mode" or "namespace-alias" or
+        "strip-space" or "preserve-space" or "use-package" or "expose" or "accept" or
+        "override" or "global-context-item";
+
+
+    /// <summary>
+    /// XTSE0730: an xsl:attribute-set with streamable="yes" may only use attribute sets that are
+    /// themselves streamable — using a non-streamable one would consume the input twice. The
+    /// use-attribute-sets list on a streamable set was not checked at all (error-0730a).
+    /// </summary>
+    private static void ValidateStreamableAttributeSets(XsltStylesheet stylesheet)
+    {
+        foreach (var (name, attrSet) in stylesheet.AttributeSets)
+        {
+            if (!attrSet.Streamable)
+                continue;
+            foreach (var usedName in attrSet.UseAttributeSets)
+            {
+                if (stylesheet.AttributeSets.TryGetValue(usedName, out var used) && !used.Streamable)
+                    throw new XsltException(
+                        $"XTSE0730: Attribute set '{name.LocalName}' is streamable, so the set '{usedName.LocalName}' it uses must be streamable too");
+            }
+        }
+    }
+
+
     private static void ValidateUseAttributeSetRefsInInstructions(XsltSequenceConstructor body, XsltStylesheet stylesheet)
     {
         foreach (var instruction in body.Instructions)

--- a/src/PhoenixmlDb.Xslt/Engine/XsltDocumentFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltDocumentFunction.cs
@@ -77,6 +77,7 @@ internal sealed class XsltDocumentFunction : PhoenixmlDb.XQuery.Ast.XQueryFuncti
                 uri = uri[..hashIdx];
             }
 
+            RequireBaseUriForNodeArgument(item, nodeBaseUri, uri);
             if (context is PhoenixmlDb.XQuery.Execution.QueryExecutionContext qc &&
                 qc.DocumentResolver is not null)
             {
@@ -127,6 +128,7 @@ internal sealed class XsltDocumentFunction : PhoenixmlDb.XQuery.Ast.XQueryFuncti
             uri = uri[..hashIdx];
         }
 
+        RequireBaseUriForNodeArgument(arg, nodeBaseUri, uri);
         if (context is PhoenixmlDb.XQuery.Execution.QueryExecutionContext queryContext &&
             queryContext.DocumentResolver is not null)
         {
@@ -203,6 +205,23 @@ internal sealed class XsltDocumentFunction : PhoenixmlDb.XQuery.Ast.XQueryFuncti
     /// <summary>
     /// Resolves a relative URI against a given base URI string.
     /// </summary>
+    /// <summary>
+    /// When the argument is a NODE, a relative reference resolves against that node's base URI
+    /// (XSLT 3.0 §20.1). A node with no base URI — a parentless text node built by a variable —
+    /// leaves nothing to resolve against, which is XTDE1162. It fell back to the static base
+    /// instead and then failed to retrieve, reporting FODC0005 (error-1162a).
+    /// </summary>
+    private static void RequireBaseUriForNodeArgument(object? item, string? nodeBaseUri, string uri)
+    {
+        if (item is not Xdm.Nodes.XdmNode || nodeBaseUri != null || uri.Length == 0)
+            return;
+        if (Uri.TryCreate(uri, UriKind.Absolute, out _))
+            return;
+        throw new XsltException(
+            $"XTDE1162: The relative URI '{uri}' cannot be resolved: the node supplied to document() has no base URI");
+    }
+
+
     private static string ResolveUriAgainstBase(string uri, string baseUriStr)
     {
         if (string.IsNullOrEmpty(baseUriStr))

--- a/tests/PhoenixmlDb.Xslt.Tests/MiscErrorCodeTests3.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/MiscErrorCodeTests3.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A third batch of error codes that named a different rule than the one broken.
+/// </summary>
+public sealed class MiscErrorCodeTests3
+{
+    private static async Task<string> RunAsync(string stylesheet, string source = "<doc/>")
+    {
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(stylesheet);
+        return (await t.TransformAsync(source)).Trim();
+    }
+
+    private static async Task AssertErrorAsync(string stylesheet, string code)
+    {
+        var act = () => RunAsync(stylesheet);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain(code);
+    }
+
+    private static string Wrap(string declarations, string body = "") => $"""
+        <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+          <xsl:output method="text"/>
+          {declarations}
+          <xsl:template match="/">{body}</xsl:template>
+        </xsl:stylesheet>
+        """;
+
+    /// <summary>
+    /// The content of xsl:key is a sequence constructor, so a declaration there is not allowed
+    /// content at all: XTSE0010. It was reported as XTSE1205 "both a use attribute and content",
+    /// which describes a different mistake (key-092).
+    /// </summary>
+    [Fact]
+    public Task Key_WithADeclarationAsContent_IsXTSE0010()
+        => AssertErrorAsync(Wrap("""
+            <xsl:key name="k" match="p" use=".//term"><xsl:template match="/"/></xsl:key>
+            """), "XTSE0010");
+
+    [Fact]
+    public Task Key_WithBothUseAndASequenceConstructor_IsStillXTSE1205()
+        => AssertErrorAsync(Wrap("""
+            <xsl:key name="k" match="p" use=".//term"><xsl:value-of select="."/></xsl:key>
+            """), "XTSE1205");
+
+    /// <summary>
+    /// A streamable attribute set may only use streamable ones — using a non-streamable set would
+    /// consume the input twice (XTSE0730). The list was not checked at all (error-0730a).
+    /// </summary>
+    [Fact]
+    public Task AStreamableAttributeSet_UsingANonStreamableOne_IsXTSE0730()
+        => AssertErrorAsync(Wrap("""
+            <xsl:attribute-set name="a" streamable="yes" use-attribute-sets="b"><xsl:attribute name="x" select="1"/></xsl:attribute-set>
+            <xsl:attribute-set name="b"><xsl:attribute name="y" select="1"/></xsl:attribute-set>
+            """), "XTSE0730");
+
+    [Fact]
+    public async Task AStreamableAttributeSet_UsingAStreamableOne_Compiles()
+        => (await RunAsync(Wrap("""
+            <xsl:attribute-set name="a" streamable="yes" use-attribute-sets="b"><xsl:attribute name="x" select="1"/></xsl:attribute-set>
+            <xsl:attribute-set name="b" streamable="yes"><xsl:attribute name="y" select="2"/></xsl:attribute-set>
+            """, "ok"))).Should().Be("ok");
+
+    /// <summary>
+    /// When document() is given a NODE, a relative reference resolves against that node's base
+    /// URI. A parentless text node built by a variable has none, leaving nothing to resolve
+    /// against: XTDE1162. It fell back to the static base and then reported a retrieval failure
+    /// (error-1162a).
+    /// </summary>
+    [Fact]
+    public Task Document_WithANodeThatHasNoBaseUri_IsXTDE1162()
+        => AssertErrorAsync(Wrap("""<xsl:variable name="t" as="text()"><xsl:value-of select="'abcd.xml'"/></xsl:variable>""",
+            """<xsl:copy-of select="document($t)"/>"""), "XTDE1162");
+
+    /// <summary>A string argument still resolves against the static base URI.</summary>
+    [Fact]
+    public Task Document_WithAStringUri_StillUsesTheStaticBase()
+        => AssertErrorAsync(Wrap("", """<xsl:copy-of select="document('abcd.xml')"/>"""), "FODC0005");
+}


### PR DESCRIPTION
| Case | Was | Now |
|---|---|---|
| a declaration (e.g. `xsl:template`) inside `xsl:key` | XTSE1205 | XTSE0010 |
| streamable `xsl:attribute-set` using a non-streamable one | not checked | XTSE0730 |
| `document(node)` where the node has no base URI | FODC0005 | XTDE1162 |

- **`xsl:key` content** is a sequence constructor, so a declaration there is not allowed content at all. XTSE1205 ("must not have both a use attribute and non-empty content") describes a different mistake, and it fired first.
- **Streamable attribute sets**: using a non-streamable set would consume the input twice, so XTSE0730 forbids it. The list was never inspected.
- **`document()` with a node argument**: a relative reference resolves against *that node's* base URI (XSLT 3.0 §20.1). A parentless text node — one built by an `xsl:variable` — has none, leaving nothing to resolve against: XTDE1162. The code fell back to the static base URI and then reported the retrieval failure. A string argument still uses the static base, and a node that has a base URI is unaffected.

**Tests:** `MiscErrorCodeTests3`, 6 cases, including controls that `use` plus a sequence constructor is still XTSE1205, that a streamable set using a streamable set compiles, and that a string URI still resolves against the static base. 3 of the 6 fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): +3, zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn