### PR TITLE
xsl:iterate child order, and an href that is not a URI

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Output.cs
@@ -1636,6 +1636,16 @@ internal sealed partial class DefaultXsltExecutionContext
             // Use instruction's effective base URI (accounts for xml:base), falling back to stylesheet base
             var baseUri = instruction.BaseUri ?? _stylesheet.BaseUri;
 
+            // A href that is not a URI reference at all — a Windows path such as
+            // c:\my\doc\books.xml — is FODC0005 (invalid argument), not FODC0002 (a valid URI
+            // that cannot be retrieved). The backslashes were silently rewritten into a file:
+            // URI, which then reported "document not found" (W3C stream-006, non-stream-006).
+            foreach (var ch in hrefForResolve)
+            {
+                if (ch is '\\' or '<' or '>' or '"' or '{' or '}' or '|' or '^' or '`' || char.IsControl(ch))
+                    throw Error($"FODC0005: Invalid URI '{href}': the character '{ch}' is not allowed in a URI reference");
+            }
+
             if (Uri.TryCreate(hrefForResolve, UriKind.Absolute, out var absUri))
             {
                 resolvedUri = absUri;

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.ControlFlow.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.ControlFlow.cs
@@ -265,6 +265,36 @@ public sealed partial class StylesheetParser
 
         var expandText = IsExpandTextActive(element);
 
+        // XTSE0010: the content of xsl:iterate is (xsl:param*, xsl:on-completion?, sequence
+        // constructor) — in that order. Checked BEFORE the children are parsed, because a
+        // misplaced xsl:param is otherwise reported by whatever its own body trips over first:
+        // "$x is not defined" for a param whose select reads a variable declared above it
+        // (iterate-008/901), or an attribute error inside a misplaced xsl:on-completion
+        // (iterate-024).
+        var seenNonParam = false;
+        var seenOnCompletion = false;
+        foreach (var child in element.Elements())
+        {
+            if (!ShouldIncludeElement(child))
+                continue;
+            var isParam = child.Name == XsltNs + "param";
+            var isOnCompletion = child.Name == XsltNs + "on-completion";
+            if (isParam && seenNonParam)
+                throw new XsltException(
+                    "XTSE0010: xsl:param must come first in xsl:iterate, before any other content",
+                    GetSourceLocation(child));
+            if (isOnCompletion && seenOnCompletion)
+                throw new XsltException(
+                    "XTSE0010: xsl:iterate must not have more than one xsl:on-completion",
+                    GetSourceLocation(child));
+            if (isOnCompletion && seenNonParam)
+                throw new XsltException(
+                    "XTSE0010: xsl:on-completion must come before the body of xsl:iterate, after any xsl:param",
+                    GetSourceLocation(child));
+            seenOnCompletion |= isOnCompletion;
+            seenNonParam |= !isParam;
+        }
+
         foreach (var node in element.Nodes())
         {
             switch (node)

--- a/tests/PhoenixmlDb.Xslt.Tests/IterateOrderAndSourceUriTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/IterateOrderAndSourceUriTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Two rules that were reported as whatever the code tripped over first: the order of children in
+/// xsl:iterate, and an href that is not a URI reference at all.
+/// </summary>
+public sealed class IterateOrderAndSourceUriTests
+{
+    private static async Task<string> RunAsync(string body, string source = "<doc><a/><a/></doc>", Uri? baseUri = null)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:template match="/">{body}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss, baseUri);
+        return (await t.TransformAsync(source)).Trim();
+    }
+
+    private static async Task AssertErrorAsync(string body, string code, Uri? baseUri = null)
+    {
+        var act = () => RunAsync(body, baseUri: baseUri);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain(code);
+    }
+
+    /// <summary>
+    /// xsl:param must come first. A param whose select reads a variable declared above it was
+    /// reported as "$x is not defined" — the consequence, not the mistake (W3C iterate-008/901).
+    /// </summary>
+    [Fact]
+    public Task Iterate_WithAParamAfterOtherContent_IsXTSE0010()
+        => AssertErrorAsync("""
+            <xsl:iterate select="//a">
+              <xsl:variable name="x" select="29"/>
+              <xsl:param name="total" as="xs:decimal" select="$x"/>
+              <xsl:next-iteration><xsl:with-param name="total" select="$total + 1"/></xsl:next-iteration>
+            </xsl:iterate>
+            """, "XTSE0010");
+
+    [Fact]
+    public Task Iterate_WithOnCompletionAfterTheBody_IsXTSE0010()
+        => AssertErrorAsync("""
+            <xsl:iterate select="//a">
+              <x/>
+              <xsl:on-completion>done</xsl:on-completion>
+            </xsl:iterate>
+            """, "XTSE0010");
+
+    [Fact]
+    public Task Iterate_WithTwoOnCompletions_IsXTSE0010()
+        => AssertErrorAsync("""
+            <xsl:iterate select="//a">
+              <xsl:on-completion>one</xsl:on-completion>
+              <xsl:on-completion>two</xsl:on-completion>
+            </xsl:iterate>
+            """, "XTSE0010");
+
+    [Fact]
+    public async Task Iterate_InTheRightOrder_StillRuns()
+        => (await RunAsync("""
+            <xsl:iterate select="//a">
+              <xsl:param name="n" select="0"/>
+              <xsl:on-completion><xsl:value-of select="$n"/></xsl:on-completion>
+              <xsl:next-iteration><xsl:with-param name="n" select="$n + 1"/></xsl:next-iteration>
+            </xsl:iterate>
+            """)).Should().Be("2");
+
+    /// <summary>
+    /// A href that is not a URI reference — a Windows path — is FODC0005 (an invalid argument),
+    /// not FODC0002 (a valid URI that cannot be retrieved). The backslashes were rewritten into a
+    /// file: URI, which then reported "document not found" (W3C stream-006, non-stream-006).
+    /// </summary>
+    [Fact]
+    public Task SourceDocument_WithAHrefThatIsNotAUri_IsFODC0005()
+        => AssertErrorAsync("""<xsl:source-document href="c:\my\doc\books.xml"><x/></xsl:source-document>""", "FODC0005");
+
+    [Fact]
+    public Task SourceDocument_WithAValidUriThatIsMissing_IsStillFODC0002()
+        => AssertErrorAsync("""<xsl:source-document href="absent-document.xml"><x/></xsl:source-document>""", "FODC0002",
+            new Uri(Path.Combine(Path.GetTempPath(), "phoenixml-absent-base.xsl")));
+}


### PR DESCRIPTION
Two rules that were reported as whatever the code tripped over first.

**`xsl:iterate` child order.** Its content is `(xsl:param*, xsl:on-completion?, sequence-constructor)`, in that order. Nothing checked it, so a misplaced `xsl:param` surfaced as a consequence rather than the mistake: a param whose `select` reads a variable declared above it was reported as `XPST0008: Variable $x not defined`. The order is now checked before the children are parsed, so the diagnosis reaches the user first — XTSE0010, naming the misplaced element.

**An href that is not a URI.** `xsl:source-document href="c:\my\doc\books.xml"` is an invalid argument (FODC0005), not a valid URI that cannot be retrieved (FODC0002). The backslashes were silently rewritten into a `file:` URI, which then reported "document not found" — pointing the user at a missing file rather than at the path they wrote. A href carrying a character that is not allowed in a URI reference is now FODC0005; a well-formed URI that is missing stays FODC0002 (stream-002).

**Tests:** `IterateOrderAndSourceUriTests`, 6 cases, including controls that a correctly ordered `xsl:iterate` still runs and that a missing-but-valid URI is still FODC0002. 4 of the 6 fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): +4, zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn