### PR TITLE
A streamed accumulator keeps its running value at a matched element

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
@@ -299,6 +299,14 @@ internal sealed partial class DefaultXsltExecutionContext
 
     private AsBodyCapture? _currentAsBodyCapture;
 
+    /// <summary>
+    /// Buffered-subtree root id → the streamed element it was materialised from. A template body
+    /// that needs the whole subtree runs on a copy with fresh node ids, which carries none of the
+    /// accumulator values the streaming pass recorded; this is how the pre-descent value is found
+    /// again. See <see cref="TryGetStreamedAccumulatorBefore"/>.
+    /// </summary>
+    internal Dictionary<NodeId, NodeId>? _bufferedSubtreeOrigin;
+
 
     private int _textOutputModeDepth; // >0 when inside method="text" result-document; text from xsl:sequence/value-of gets sentinel-escaped to protect from StripXmlMarkup
 

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.cs
@@ -1354,6 +1354,19 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
             // here (unlike the prior ReadOuterXml path, which advanced too far).
             bufferedRoot = StreamingSubtreeMaterializer.Materialize(reader, _nodeStore, new DocumentId(0))
                            ?? element;
+            // The buffered subtree is a FRESH set of nodes, so the accumulator values the
+            // streaming pass recorded against the streamed element do not reach the body that
+            // runs on the copy. accumulator-before() found nothing there and recomputed the
+            // accumulator from its initial value over this one node — so every match reported
+            // the same value, whatever the stream had accumulated (W3C accumulator-001s and its
+            // siblings: "Figure 1" four times where the non-streamed run counts 1, 2, 1, 2).
+            //
+            // Only the origin is recorded, not the values: the pre-descent value is final at the
+            // start tag, but the post-descent one is not — the element's end-phase rules have not
+            // run yet — so accumulator-after() must still be answered by the walk over the
+            // buffered subtree (accumulator-015s/036s/069s).
+            if (!ReferenceEquals(bufferedRoot, element))
+                (_bufferedSubtreeOrigin ??= new Dictionary<NodeId, NodeId>())[bufferedRoot.Id] = element.Id;
         }
         else
         {
@@ -3018,6 +3031,26 @@ internal sealed partial class DefaultXsltExecutionContext : XsltExecutionContext
     /// <summary>
     /// Looks up a pre-computed accumulator value for the given node.
     /// </summary>
+    /// <summary>
+    /// The pre-descent accumulator value recorded by the streaming pass for the element a buffered
+    /// subtree was materialised from, or null when this node is not such a copy (or the streaming
+    /// pass recorded nothing for it).
+    /// </summary>
+    internal bool TryGetStreamedAccumulatorBefore(QName accumulatorName, object node, out object? value)
+    {
+        value = null;
+        if (_bufferedSubtreeOrigin == null || _accumulatorValues == null || node is not XdmNode xdmNode)
+            return false;
+        if (!_bufferedSubtreeOrigin.TryGetValue(xdmNode.Id, out var streamedId))
+            return false;
+        if (!_accumulatorValues.TryGetValue(accumulatorName, out var nodeValues)
+            || !nodeValues.TryGetValue(streamedId, out var recorded))
+            return false;
+        value = recorded.before;
+        return true;
+    }
+
+
     internal (object? before, object? after)? GetAccumulatorValue(QName accumulatorName, object node, bool isAfter = false)
     {
         if (_accumulatorValues == null)

--- a/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltAccumulatorBeforeFunction.cs
@@ -55,6 +55,16 @@ internal sealed class XsltAccumulatorBeforeFunction : PhoenixmlDb.XQuery.Ast.XQu
             throw new XsltException($"XTDE3340: Accumulator '{name}' is not applicable in the current mode (not listed in use-accumulators)");
         }
 
+        // A template body that needs the whole subtree runs on a buffered copy of the streamed
+        // element, whose fresh node ids carry none of the streaming pass's values. The pre-descent
+        // value was final when that copy was taken, so it is read from the element it came from.
+        if (_context.TryGetStreamedAccumulatorBefore(accName, node, out var streamedBefore))
+        {
+            if (streamedBefore is AccumulatorDeferredError streamedError)
+                streamedError.Rethrow();
+            return streamedBefore;
+        }
+
         // Lazily compute accumulators for this document if not yet done
         await _context.EnsureAccumulatorsComputedAsync(accName, node).ConfigureAwait(false);
         await _context.EnsureAccumulatorPhaseAsync(accName, node, isAfter: false).ConfigureAwait(false);

--- a/tests/PhoenixmlDb.Xslt.Tests/StreamingAccumulatorValueTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/StreamingAccumulatorValueTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Under a streamable mode, accumulator-before() at a matched element answers what the streaming
+/// pass accumulated. A template body that needs the whole subtree runs on a buffered copy of the
+/// streamed element, and those fresh node ids carried none of the pass's values: the lookup found
+/// nothing and recomputed the accumulator from its initial value over that one node, so every
+/// match reported the same value (W3C accumulator-001s and siblings).
+/// </summary>
+public sealed class StreamingAccumulatorValueTests
+{
+    private const string Source = """
+        <doc>
+          <chap><div><fig alt="a"/></div><div><fig alt="b"/></div></chap>
+          <chap><div><fig alt="c"/></div><div><fig alt="d"/></div></chap>
+        </doc>
+        """;
+
+    private static async Task<string> RunAsync(string streamable, bool streamed)
+    {
+        // The fig template reads @alt as well as the accumulator, so its body needs the buffered
+        // subtree — the path where the values went missing.
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:accumulator name="figNr" as="xs:integer" initial-value="0" streamable="{streamable}">
+                <xsl:accumulator-rule match="chap" select="0"/>
+                <xsl:accumulator-rule match="fig" select="$value + 1"/>
+              </xsl:accumulator>
+              <xsl:mode streamable="{streamable}" on-no-match="shallow-skip" use-accumulators="figNr"/>
+              <xsl:template match="fig"><xsl:value-of select="accumulator-before('figNr')"/><xsl:value-of select="@alt"/><xsl:text> </xsl:text></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (streamed ? await t.TransformAsync(new StringReader(Source)) : await t.TransformAsync(Source)).Trim();
+    }
+
+    [Fact]
+    public async Task AStreamedAccumulator_KeepsItsRunningValue_AtAMatchedElement()
+        => (await RunAsync("yes", streamed: true)).Should().Be("1a 2b 1c 2d",
+            "the streamed run reported 1 at every fig, whatever the pass had accumulated");
+
+    [Fact]
+    public async Task TheNonStreamedRun_IsUnchanged()
+        => (await RunAsync("no", streamed: false)).Should().Be("1a 2b 1c 2d");
+
+    /// <summary>
+    /// The post-descent value is NOT final when the copy is taken — the element's end-phase rules
+    /// have not run yet — so accumulator-after() is still answered by the walk over the buffered
+    /// subtree (accumulator-015s/036s/069s regressed when it was answered from the copy).
+    /// </summary>
+    /// <remarks>
+    /// One chap, so the subtree walk and the whole-stream value agree. They do not agree for a
+    /// LATER sibling — a streamed accumulator-after counts only the matched subtree, so a second
+    /// chap reports 2 where the non-streamed run reports 4. That gap is older than this fix and is
+    /// left as it was; asserting it here either way would enshrine it.
+    /// </remarks>
+    [Fact]
+    public async Task AccumulatorAfter_CountsTheSubtree()
+    {
+        var ss = """
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              <xsl:accumulator name="figNr" as="xs:integer" initial-value="0" streamable="yes">
+                <xsl:accumulator-rule match="fig" select="$value + 1"/>
+              </xsl:accumulator>
+              <xsl:mode streamable="yes" on-no-match="shallow-skip" use-accumulators="figNr"/>
+              <xsl:template match="chap"><xsl:value-of select="accumulator-after('figNr'), count(.//fig)"/><xsl:text> </xsl:text></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        const string oneChap = """<doc><chap><div><fig alt="a"/></div><div><fig alt="b"/></div></chap></doc>""";
+        (await t.TransformAsync(new StringReader(oneChap))).Trim().Should().Be("2 2");
+    }
+}


### PR DESCRIPTION
Under a streamable mode, `accumulator-before()` at a matched element reported the same value at every match, whatever the pass had accumulated: `Figure 1` at all four figures where the non-streamed run counts `1, 2, 1, 2`.

**Why.** A template body that needs the whole subtree (this one reads `@alt` as well as the accumulator) runs on a buffered copy materialised from the live reader. The copy is a fresh set of nodes, so the per-node values the streaming pass recorded against the streamed element were not found for it. The lookup then fell through to `EnsureAccumulatorsComputedAsync`, which wrapped that single node in a temporary document and recomputed the accumulator from its initial value — producing `initial + one rule firing`, identically, at every match. A probe rule matching `/` re-fired once per figure, which only happens on a recompute.

**The fix** records where the copy came from — buffered root id → streamed element id — and answers `accumulator-before()` from the streamed element's recorded value.

Only the origin, not the values: the pre-descent value is final when the copy is taken, but the post-descent value is not — the element's end-phase rules have not run yet. Copying both (my first attempt) handed `accumulator-after()` a premature value and regressed accumulator-015s, 036s and 069s, all of which read the after-value; those are still answered by the walk over the buffered subtree.

**Tests:** `StreamingAccumulatorValueTests` — the streamed run now matches the non-streamed one, plus a non-streamed control and an `accumulator-after()` control. The streamed case fails on main.

A separate, older gap is left alone and noted in the test: a streamed `accumulator-after()` counts only the matched subtree, so a second sibling reports 2 where the non-streamed run reports 4.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): accumulator-001s, accumulator-035s and accumulator-054 now pass; +3 with zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn