### PR TITLE
An accumulator in an attribute value template sees the whole stream

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/StreamingSubtreeBufferDetector.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StreamingSubtreeBufferDetector.cs
@@ -324,7 +324,9 @@ internal static class StreamingSubtreeBufferDetector
                 // element (e.g. <banana x="{count(//*)}"/>) gets no watcher/document-level
                 // streaming dispatch — it evaluates against the synthetic empty node and folds
                 // to "" / 0. Any input-navigating AVT therefore needs the whole-input buffer. (#143)
-                return AttributesNavigateInput(lre.Attributes) || RequiresWholeInputBuffer(lre.Content);
+                return AttributesNavigateInput(lre.Attributes)
+                    || AttributesReferenceContextAccumulator(lre.Attributes)
+                    || RequiresWholeInputBuffer(lre.Content);
 
             case XsltCopy cp:
                 // xsl:copy select="path" navigates INTO the input to pick the node to copy,
@@ -431,6 +433,25 @@ internal static class StreamingSubtreeBufferDetector
         foreach (var avt in attrs.Values)
             foreach (var part in avt.Parts)
                 if (part is AvtExpression ae && NavigatesInput(ae.Expression))
+                    return true;
+        return false;
+    }
+
+
+    /// <summary>
+    /// True when any attribute value template in <paramref name="attrs"/> reads an accumulator
+    /// against the context node. At the document level that value is only known once the whole
+    /// tree has been consumed, exactly as for a select (see
+    /// <see cref="SelectReferencesContextAccumulator"/>) — but an accumulator call navigates
+    /// nothing, so the navigation test above does not see it, and
+    /// <c>&lt;result count="{accumulator-after('count')}"/&gt;</c> folded to the initial value
+    /// while the same call in an xsl:value-of was routed correctly (W3C accumulator-009s/019s).
+    /// </summary>
+    private static bool AttributesReferenceContextAccumulator(IReadOnlyDictionary<QName, XsltAttributeValueTemplate> attrs)
+    {
+        foreach (var avt in attrs.Values)
+            foreach (var part in avt.Parts)
+                if (part is AvtExpression ae && SelectReferencesContextAccumulator(ae.Expression))
                     return true;
         return false;
     }

--- a/tests/PhoenixmlDb.Xslt.Tests/StreamingAvtAccumulatorTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/StreamingAvtAccumulatorTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// An accumulator read against the context node at the document level needs the value AFTER the
+/// whole tree is consumed, so such a body runs over the whole input. That was detected for a
+/// select but not for an attribute value template: an accumulator call navigates nothing, and the
+/// AVT check only looked for input navigation. So the same call folded to the accumulator's
+/// initial value in <c>&lt;result count="{accumulator-after('count')}"/&gt;</c> while working in
+/// an xsl:value-of — silently, with a plausible number.
+/// </summary>
+public sealed class StreamingAvtAccumulatorTests
+{
+    private const string Source = """<doc><t amount="10"/><t amount="30"/><t amount="2"/></doc>""";
+
+    private static async Task<string> RunAsync(string body, bool streamed)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
+              <xsl:output method="xml" omit-xml-declaration="yes"/>
+              <xsl:accumulator name="count" as="xs:integer" initial-value="0" streamable="yes">
+                <xsl:accumulator-rule match="t" select="$value + 1"/>
+              </xsl:accumulator>
+              <xsl:accumulator name="total" as="xs:double" initial-value="0" streamable="yes">
+                <xsl:accumulator-rule match="t" select="$value + @amount"/>
+              </xsl:accumulator>
+              <xsl:mode streamable="yes" on-no-match="deep-skip" use-accumulators="count total"/>
+              <xsl:template match="/">{body}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (streamed ? await t.TransformAsync(new StringReader(Source)) : await t.TransformAsync(Source)).Trim();
+    }
+
+    private const string AvtBody = """<result count="{accumulator-after('count')}" total="{accumulator-after('total')}"/>""";
+    private const string ValueOfBody = """<result><xsl:value-of select="accumulator-after('count')"/>|<xsl:value-of select="accumulator-after('total')"/></result>""";
+
+    [Fact]
+    public async Task AnAccumulatorInAnAvt_SeesTheWholeStream()
+        => (await RunAsync(AvtBody, streamed: true)).Should().Be("""<result count="3" total="42"/>""",
+            "the streamed run reported the accumulators' initial values");
+
+    /// <summary>
+    /// Unstreamed, the same stylesheet answered the initial values too — the mode is streamable
+    /// either way, so a test that only compared the two runs would have passed while both were
+    /// wrong.
+    /// </summary>
+    [Fact]
+    public async Task AnAccumulatorInAnAvt_SeesTheWholeTree_Unstreamed()
+        => (await RunAsync(AvtBody, streamed: false)).Should().Be("""<result count="3" total="42"/>""");
+
+    /// <summary>The same calls in an xsl:value-of were already routed correctly.</summary>
+    [Fact]
+    public async Task AnAccumulatorInAValueOf_IsUnchanged()
+        => (await RunAsync(ValueOfBody, streamed: true)).Should().Be("<result>3|42</result>");
+}


### PR DESCRIPTION
`<result count="{accumulator-after('count')}"/>` in a `match="/"` template under a streamable mode reported the accumulator's **initial** value — a plausible `0` — while the identical call in an `xsl:value-of` reported the right one.

**Why.** At the document level, an accumulator read against the context node needs the value after the whole tree has been consumed, so such a body is routed to the whole-input buffer. The detector recognised that for a `select`, but the attribute-value-template check asked a different question: *does this expression navigate the input?* An accumulator call navigates nothing, so the AVT was judged groundable and the body stayed on the single forward pass, where the value is still the initial one.

The property that matters is "does this need the whole input", and navigation was standing in for it. That proxy is right for every case it was written against and silently wrong for the one function family that consumes the input without touching a path.

**No conformance movement.** The pinned (XQuery 1.7.0) same-checkout A/B over `--all` is flat: 2301 failures on both sides, no per-set differences. Taking it on the merits — a wrong number becomes the right one, and AVTs stop disagreeing with `xsl:value-of` about the same expression.

The corpus cases in this area (accumulator-009s, accumulator-019s) are **not** addressed here and remain failing: they expect a static XTSE3430 for this construct, while attr/mode mode-1107a/c expect the value for the same shape through `xsl:value-of` — which we pass. That contradiction needs a §streamability reading rather than a guess, and is registered.

**Tests:** `StreamingAvtAccumulatorTests` — streamed and unstreamed both assert the accumulated values, plus an `xsl:value-of` control that was already correct. Both accumulator assertions fail on main (`count="0" total="0"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn