### PR TITLE
xsl:element reports the attribute it cannot accept, not the missing name

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Construction.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Construction.cs
@@ -208,15 +208,16 @@ public sealed partial class StylesheetParser
             "name", "namespace", "use-attribute-sets", "inherit-namespaces", "validation", "type");
 
         var nameAttr = element.Attribute("name");
-        if (nameAttr == null)
-            throw new XsltException("XTSE0010: xsl:element must have a name attribute", location);
-        var name = ParseAvt(nameAttr.Value, element, nameAttr);
         var namespaceAttr = element.Attribute("namespace");
         var useAttributeSetsAttr = element.Attribute("use-attribute-sets");
         var inheritNamespacesAttr = element.Attribute("inherit-namespaces");
         var validationAttr = element.Attribute("validation");
         var typeAttr = element.Attribute("type");
 
+        // XTSE1660 comes FIRST: an attribute this processor must not accept at all is a
+        // different and more informative answer than "name is missing", and an xsl:element
+        // carrying both gets told about the one it cannot fix by adding a name
+        // (W3C error-1660b/c).
         // XTSE1660: Non-schema-aware processor must reject type attribute
         if (typeAttr != null && ShouldRejectSchemaAware)
             throw new XsltException("XTSE1660: A non-schema-aware XSLT processor must not accept the type attribute on xsl:element", location);
@@ -227,6 +228,10 @@ public sealed partial class StylesheetParser
             if (v is "strict" or "type" && ShouldRejectSchemaAware)
                 throw new XsltException($"XTSE1660: A non-schema-aware XSLT processor must not accept validation=\"{v}\" on xsl:element", location);
         }
+
+        if (nameAttr == null)
+            throw new XsltException("XTSE0010: xsl:element must have a name attribute", location);
+        var name = ParseAvt(nameAttr.Value, element, nameAttr);
 
         // XTSE0020: Validate inherit-namespaces value
         if (inheritNamespacesAttr != null && ParseYesNo(inheritNamespacesAttr) == null)

--- a/tests/PhoenixmlDb.Xslt.Tests/ElementSchemaAwareOrderTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/ElementSchemaAwareOrderTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// An xsl:element carrying an attribute this processor must not accept at all is told about that
+/// (XTSE1660) rather than about its missing name: the name is the mistake the author can fix by
+/// typing more, the schema-aware attribute is the one they cannot (W3C error-1660b/c).
+/// </summary>
+public sealed class ElementSchemaAwareOrderTests
+{
+    private static async Task AssertErrorAsync(string body, string code)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+              <xsl:template match="/">{body}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var act = async () =>
+        {
+            var t = new XsltTransformer();
+            await t.LoadStylesheetAsync(ss);
+            return await t.TransformAsync("<doc/>");
+        };
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain(code);
+    }
+
+    [Theory]
+    [InlineData("""<xsl:element type="xs:untyped"><x/></xsl:element>""")]
+    [InlineData("""<xsl:element validation="strict"><x/></xsl:element>""")]
+    public Task AnElementWithASchemaAwareAttributeAndNoName_IsXTSE1660(string body)
+        => AssertErrorAsync(body, "XTSE1660");
+
+    [Theory]
+    [InlineData("""<xsl:element name="e" type="xs:untyped"/>""")]
+    [InlineData("""<xsl:element name="e" validation="strict"/>""")]
+    public Task ANamedElementWithASchemaAwareAttribute_IsStillXTSE1660(string body)
+        => AssertErrorAsync(body, "XTSE1660");
+
+    [Fact]
+    public Task AnElementWithNoNameAndNothingElse_IsStillXTSE0010()
+        => AssertErrorAsync("<xsl:element><x/></xsl:element>", "XTSE0010");
+}


### PR DESCRIPTION
`<xsl:element type="xs:untyped">` and `<xsl:element validation="strict">` — both without a name — reported `XTSE0010: xsl:element must have a name attribute`.

Both mistakes are present, and the order matters for the reader: a missing name is fixed by typing one, while a schema-aware attribute is something this processor cannot accept at any spelling. Reporting the name first sends the author to add a name and hit the second error afterwards. XTSE1660 now comes first.

A missing name with nothing else wrong is still XTSE0010, and a *named* element carrying `type` or `validation="strict"` is unchanged.

**Tests:** `ElementSchemaAwareOrderTests`, 5 cases — both schema-aware attributes with and without a name, plus the plain missing-name control. The two no-name cases fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): error-1660b and error-1660c now pass; +2 with zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn