### PR TITLE
A function argument the conversion rules reject is XPTY0004

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Functions.cs
@@ -2130,8 +2130,10 @@ internal sealed partial class DefaultXsltExecutionContext
             SetVariable(new QName(NamespaceId.None, "current-merge-key"), null);
 
             // Bind parameters with function conversion rules (XSLT 3.0 §5.4.1):
-            // Atomize node values and coerce to target type when target is atomic
-            // Then validate with XTTE0790 for strict atomic types
+            // Atomize node values and coerce to target type when target is atomic.
+            // A value the conversion rules cannot convert is XPTY0004 — the code XSLT 3.0
+            // gives this; XTTE0790 was its 2.0 spelling, and the 2.0-only corpus case that
+            // still expects it is skipped as a 3.0 processor (W3C error-0790a3 vs 0790a2).
             for (var i = 0; i < func.Parameters.Count && i < arguments.Count; i++)
             {
                 var param = func.Parameters[i];
@@ -2140,7 +2142,7 @@ internal sealed partial class DefaultXsltExecutionContext
                 {
                     // Apply function conversion rules: atomize nodes, coerce to target type
                     value = ApplyFunctionConversionRules(value, param.As);
-                    ValidateValueMatchesType(value, param.As, "XTTE0790",
+                    ValidateValueMatchesType(value, param.As, "XPTY0004",
                         $"Value of parameter ${param.Name.LocalName} in function {func.Name.LocalName}");
                 }
                 else if (param.As != null && param.As.ItemType == ItemType.Function

--- a/tests/PhoenixmlDb.Xslt.Tests/FunctionArgumentConversionTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/FunctionArgumentConversionTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// An argument the function conversion rules cannot convert to a stylesheet function's declared
+/// parameter type is XPTY0004 (XSLT 3.0 §5.4.1). XTTE0790 was the XSLT 2.0 spelling of the same
+/// error and is not a 3.0 code (W3C error-0790a3, whose 2.0 twin error-0790a2 still expects the
+/// old one and is skipped as a 3.0 processor).
+/// </summary>
+public sealed class FunctionArgumentConversionTests
+{
+    private static async Task<string> RunAsync(string body, string declarations)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="urn:my" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              {declarations}
+              <xsl:template match="/">{body}</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (await t.TransformAsync("<doc/>")).Trim();
+    }
+
+    private const string DateFunction = """<xsl:function name="my:f"><xsl:param name="x" as="xs:date"/><xsl:sequence select="string($x)"/></xsl:function>""";
+
+    [Fact]
+    public async Task AnArgumentThatCannotBeConverted_IsXPTY0004()
+    {
+        var act = () => RunAsync("""<xsl:value-of select="my:f(2)"/>""", DateFunction);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XPTY0004");
+    }
+
+    /// <summary>
+    /// The conversion rules still apply: a typed value of the right type passes, and an UNTYPED
+    /// one (a node's atomized value) is converted. A string is not — xs:string does not convert
+    /// to xs:date — so that case is XPTY0004 too, which is why the control uses a node.
+    /// </summary>
+    [Theory]
+    [InlineData("""my:f(xs:date('2026-09-11'))""")]
+    [InlineData("""my:f(/doc/@d)""")]
+    public async Task AnArgumentTheRulesCanConvert_StillWorks(string call)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="urn:my" exclude-result-prefixes="#all">
+              <xsl:output method="text"/>
+              {DateFunction}
+              <xsl:template match="/"><xsl:value-of select="{call}"/></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        (await t.TransformAsync("""<doc d="2026-09-11"/>""")).Trim().Should().Be("2026-09-11");
+    }
+
+    [Fact]
+    public async Task AnIntegerParameterGivenAString_IsXPTY0004()
+    {
+        var act = () => RunAsync("""<xsl:value-of select="my:g('banana')"/>""",
+            """<xsl:function name="my:g"><xsl:param name="n" as="xs:integer"/><xsl:sequence select="$n"/></xsl:function>""");
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("XPTY0004");
+    }
+}


### PR DESCRIPTION
Calling a stylesheet function with an argument the function conversion rules cannot convert to the declared parameter type reported XTTE0790. That is the **XSLT 2.0** spelling of the error; XSLT 3.0 §5.4.1 gives XPTY0004.

The corpus has both codes for the same stylesheet, split by spec version — error-0790a2 (`<spec value="XSLT20"/>`, XTTE0790) and error-0790a3 (`<spec value="XSLT30+"/>`, XPTY0004). The runner already skips XSLT20-only cases, so the 2.0 twin is not run, and decl/function function-1019 accepts either code.

**Tests:** `FunctionArgumentConversionTests`, 4 cases. Both rejection cases fail on main. The controls are worth a note: a *string* argument for an `xs:date` parameter is also XPTY0004 — the conversion rules convert untyped values, not strings — so the controls pass a typed `xs:date` and an untyped attribute node instead.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): error-0790a3, evaluate-022 and initial-function-102b now pass; +3, no losses (call-template-1002 is a known flicker that fails on main as well).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn