### PR TITLE
An empty transform result is assertable

### DIFF
--- a/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
+++ b/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
@@ -1439,14 +1439,36 @@ public sealed class XsltTestRunner
             var toParse = text.Contains('<', StringComparison.Ordinal)
                 ? text
                 : $"<phx-text-result>{System.Security.SecurityElement.Escape(text)}</phx-text-result>";
+            // An EMPTY result is a document node with no children — valid XDM, and what a
+            // transform that matched nothing produces. The wrapper above would give it one
+            // element child, so `not(/node())` (the assertion such tests use) saw a node and
+            // failed. The engine's answer was right and unscoreable. Build the empty document
+            // instead. (W3C misc/error error-0045aa/ab.)
             // Deliberately NOT WrapForParsing: a wrapper element would shift every absolute
             // path in the assertion by one step, so /result/@count would stop matching. Output
             // that is not a single well-formed document therefore fails to parse and the
             // assertion fails — which is the honest outcome, since such a result has no tree
             // for an absolute path to address.
-            var doc = store.LoadFromString(toParse, "urn:xslt-result");
-
             var engine = new PhoenixmlDb.XQuery.Execution.QueryEngine(nodeProvider: store, documentResolver: store);
+            object? doc;
+            if (text.Length == 0)
+            {
+                var emptyDoc = engine.Compile("document{()}");
+                if (!emptyDoc.Success) return false;
+                object? built = null;
+                await foreach (var item in emptyDoc.ExecutionPlan!
+                    .ExecuteAsync(engine.CreateContext(cancellationToken: ct)).ConfigureAwait(false))
+                {
+                    built = item;
+                    break;
+                }
+                if (built == null) return false;
+                doc = built;
+            }
+            else
+            {
+                doc = store.LoadFromString(toParse, "urn:xslt-result");
+            }
 
             // Parse with NormalizeLineEndings OFF, then compile the AST. QueryEngine.Compile(string)
             // builds its own parser with XQuery's query-SOURCE defaults, which apply §A.2.1


### PR DESCRIPTION
Two W3C cases (misc/error error-0045aa, error-0045ab) invoke a stylesheet with an initial mode that matches nothing and assert `not(/node())` — the transform must produce nothing. The engine produced exactly that. The harness could not score it.

**Why.** A markup-free result is wrapped in a synthetic `<phx-text-result>` element so a text-only result still has a tree for its assertions to address. An **empty** result went down the same path, so it acquired an element child: `not(/node())` saw a node and returned false.

An empty result is now evaluated as what XDM says it is — a document node with no children, built by evaluating `document{()}`. Assertions that read content (`/out = 'x'`) still fail against it, so the context is more accurate rather than more lenient.

This is a harness fix, not an engine one: no engine behaviour changes, and the two cases were failing on a correct result.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): +2, zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn