### PR TITLE
Streamed siblings stay siblings

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Copy.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Copy.cs
@@ -514,11 +514,14 @@ internal sealed partial class DefaultXsltExecutionContext
                     if (tcAttrs != null)
                         RecordTreeAttribute(attrName, attrValue, copyNsBindings, tcNsDecls!, tcAttrs, ref tcAbort);
                 }
-                if (_isStreamingExecution && _activeStreamingReader != null)
+                if (_isStreamingExecution && _activeStreamingReader != null
+                    && !_streamingDispatchElementMaterialized)
                 {
                     // Streaming mode: leave the element open and push onto the
                     // deferred-close stack so StreamingXmlProcessor closes it when
-                    // the source element's EndElement event fires. Mirrors the
+                    // the source element's EndElement event fires. Not when the element
+                    // was already materialised — its EndElement has been consumed, so
+                    // nothing would ever pop the deferred close and the tag stayed open. Mirrors the
                     // built-in shallow-copy path. Without this, xsl:copy would emit
                     // <body>buffered</body> immediately and the processor's
                     // subsequent child events (h1, p, …) would leak out as siblings

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.State.cs
@@ -333,6 +333,15 @@ internal sealed partial class DefaultXsltExecutionContext
     // but whose end tags must be deferred until the StreamingXmlProcessor sees EndElement.
     internal readonly Stack<string> _streamingOpenElements = new();
 
+    /// <summary>
+    /// True while executing a template for an element whose subtree was already READ from the
+    /// stream (ReadStreamingElementForDispatchAsync materialises the whole element and leaves the
+    /// reader on its EndElement). An xsl:apply-templates in that body must walk the children in
+    /// memory: driving the reader instead consumes the element's FOLLOWING SIBLINGS as if they
+    /// were its children (W3C attr/mode mode-1418 and siblings).
+    /// </summary>
+    internal bool _streamingDispatchElementMaterialized;
+
     // Active streaming processor reference for triggering streaming from apply-templates
     // inside xsl:source-document Content bodies.
     internal StreamingXmlProcessor? _activeStreamingProcessor;

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
@@ -144,6 +144,7 @@ internal sealed partial class DefaultXsltExecutionContext
         // not before). Without this, apply-templates returned immediately, `<post/>`
         // emitted, then the processor's outer loop read the children as siblings.
         if (_isStreamingExecution && _activeStreamingReader != null
+            && !_streamingDispatchElementMaterialized
             && IsConsumingChildSelect(select))
         {
             await ApplyTemplatesStreamingAsync(mode, withParams).ConfigureAwait(false);
@@ -840,7 +841,10 @@ internal sealed partial class DefaultXsltExecutionContext
                 // In streaming mode, child recursion is handled by the streaming loop:
                 // we leave the element open (no closing tag) and push the qname so that
                 // StreamingXmlProcessor can write the closing tag on EndElement.
-                if (_isStreamingExecution)
+                // Only when the streaming loop will deliver this element's EndElement. For an
+                // already-materialised element the loop has passed it, so a deferred close would
+                // never be popped (the tag stays open) — close it inline instead.
+                if (_isStreamingExecution && !_streamingDispatchElementMaterialized)
                 {
                     _streamingOpenElements.Push(qname);
                     // Descendants in the streaming loop inherit this subtree's base context;
@@ -1591,7 +1595,20 @@ internal sealed partial class DefaultXsltExecutionContext
                     // Fire matching template (or default rule) inline, same path the main
                     // streaming processor uses. Pop any deferred element close on the way
                     // out — element template body's shallow-copy / xsl:copy may have pushed.
-                    await MatchAndExecuteStreamingNodeAsync(elem, mode, position).ConfigureAwait(false);
+                    // The element arrives FULLY MATERIALISED (the helper read its whole subtree
+                    // and left the reader on its EndElement), so an apply-templates inside its
+                    // body must walk those children in memory rather than read on — reading on
+                    // consumed the element's following siblings as its children.
+                    var savedMaterialized = _streamingDispatchElementMaterialized;
+                    _streamingDispatchElementMaterialized = true;
+                    try
+                    {
+                        await MatchAndExecuteStreamingNodeAsync(elem, mode, position).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        _streamingDispatchElementMaterialized = savedMaterialized;
+                    }
                     // After the template runs, the deferred-close stack may contain the
                     // element's open tag (if shallow-copy / xsl:copy was used). Close it
                     // now, since we already consumed the element's full subtree.

--- a/tests/PhoenixmlDb.Xslt.Tests/StreamingSiblingCopyTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/StreamingSiblingCopyTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// Under a streamable mode, a matched template that copies its element and applies templates to
+/// its children produces siblings as siblings. The dispatch helper materialises the WHOLE element
+/// and leaves the reader on its end tag, but the apply-templates in the body kept driving the
+/// reader — so it consumed the element's FOLLOWING SIBLINGS as if they were its children:
+/// &lt;book&gt;&lt;bktlong&gt;&lt;bktshort&gt;…, with book never closed (W3C attr/mode mode-1418).
+/// </summary>
+public sealed class StreamingSiblingCopyTests
+{
+    private const string Source = "<book><bktlong>long text</bktlong><bktshort>short</bktshort></book>";
+
+    private static async Task<string> RunAsync(string streamable, bool streamed)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="xml" omit-xml-declaration="yes"/>
+              <xsl:mode name="s" on-no-match="shallow-skip" streamable="{streamable}"/>
+              <xsl:template match="book|bktlong|bktshort" mode="s">
+                <xsl:copy><xsl:apply-templates mode="s"/></xsl:copy>
+              </xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        t.SetInitialMode("s");
+        return (streamed ? await t.TransformAsync(new StringReader(Source)) : await t.TransformAsync(Source)).Trim();
+    }
+
+    [Fact]
+    public async Task StreamedSiblings_StaySiblings()
+        => (await RunAsync("yes", streamed: true)).Should().Be("<book><bktlong/><bktshort/></book>",
+            "the streamed run nested bktshort inside bktlong and never closed book");
+
+    [Fact]
+    public async Task TheUnstreamedRun_IsUnchanged()
+        => (await RunAsync("no", streamed: false)).Should().Be("<book><bktlong/><bktshort/></book>");
+
+    /// <summary>Nested elements still nest — the fix must not flatten a real hierarchy.</summary>
+    [Fact]
+    public async Task StreamedNesting_IsPreserved()
+    {
+        var ss = """
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="xml" omit-xml-declaration="yes"/>
+              <xsl:mode name="s" on-no-match="shallow-skip" streamable="yes"/>
+              <xsl:template match="a|b|c" mode="s"><xsl:copy><xsl:apply-templates mode="s"/></xsl:copy></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        t.SetInitialMode("s");
+        (await t.TransformAsync(new StringReader("<a><b><c/></b><b/></a>"))).Trim()
+            .Should().Be("<a><b><c/></b><b/></a>");
+    }
+}


### PR DESCRIPTION
Under a streamable mode, a matched template that copies its element and applies templates to its children **turned the source's siblings into a nest**:

```
source:   <book><bktlong>long</bktlong><bktshort>short</bktshort></book>
streamed: <book><bktlong><bktshort></bktshort></bktlong>      ← and book never closed
expected: <book><bktlong/><bktshort/></book>                  ← what the unstreamed run gives
```

**Why.** The dispatch helper materialises the whole element — it reads the entire subtree and leaves the reader on that element's `EndElement`. The `xsl:apply-templates` inside the matched template body did not know that and kept driving the reader, so the first thing it read was the element's **next sibling**, which it then processed as a child. The body now walks the materialised children in memory instead.

**The second half was caught by a control, not by the corpus.** I added a nesting case (`<a><b><c/></b><b/></a>`) to check the fix did not flatten a real hierarchy, and it failed at depth 3 with `<c>` left open: `xsl:copy` and the built-in shallow-copy defer their closing tag to the streaming loop's `EndElement`, and for an already-materialised element that event has already been consumed, so nothing ever popped the deferred close. Both now close inline in that case. Without the control this would have shipped as a fix that moved the defect one level deeper.

Streamed output is now byte-identical to unstreamed for these shapes, including self-closing form.

**Tests:** `StreamingSiblingCopyTests` — streamed siblings, the unstreamed control, and the nesting control. Two fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): mode-1418, mode-1424, mode-1426, mode-1432 and streamable-111 now pass; +5 with zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn