### PR TITLE
Implement xsl:mode warning-on-no-match

### DIFF
--- a/src/PhoenixmlDb.Xslt/Ast/XsltMode.cs
+++ b/src/PhoenixmlDb.Xslt/Ast/XsltMode.cs
@@ -25,6 +25,14 @@ public sealed class XsltMode
     public OnNoMatchBehavior? OnNoMatch { get; init; }
 
     /// <summary>
+    /// xsl:mode warning-on-no-match="yes": the processor reports a warning each time a node is
+    /// processed in this mode with no matching template rule, so a stylesheet author can find the
+    /// nodes falling through to the built-in rule. Parsed but never acted on before — the
+    /// attribute was validated and dropped.
+    /// </summary>
+    public bool WarningOnNoMatch { get; init; }
+
+    /// <summary>
     /// Behavior when multiple templates match.
     /// </summary>
     public OnMultipleMatchBehavior OnMultipleMatch { get; init; } = OnMultipleMatchBehavior.UseLast;

--- a/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/DefaultXsltExecutionContext.Templates.cs
@@ -534,6 +534,7 @@ internal sealed partial class DefaultXsltExecutionContext
                     // Built-in template rules
                     if (_options?.TraceListener != null)
                         _options.TraceListener(_templateDepth, "built-in", DescribeTraceNode(node));
+                    ReportNoMatchWarning(node, mode);
                     await ApplyBuiltInTemplateAsync(node, mode, withParams).ConfigureAwait(false);
                 }
             }
@@ -1549,8 +1550,36 @@ internal sealed partial class DefaultXsltExecutionContext
         {
             // No matching template found - apply built-in template rule
             // Note: xsl:fallback is NOT executed since we support xsl:next-match
+            ReportNoMatchWarning(node, _currentMode);
             await ApplyBuiltInTemplateAsync(node, _currentMode, withParams).ConfigureAwait(false);
         }
+    }
+
+
+    /// <summary>
+    /// xsl:mode warning-on-no-match="yes": report each node processed in this mode with no
+    /// matching template rule. The attribute was parsed, validated and then dropped, so the
+    /// diagnostic it asks for was never produced (W3C attr/mode mode-1427/1428/1440/1442).
+    /// </summary>
+    private void ReportNoMatchWarning(object? node, QName? mode)
+    {
+        if (_options.WarningListener is not { } listener)
+            return;
+        var modeKey = mode ?? new QName(NamespaceId.None, "");
+        if (!_stylesheet.Modes.TryGetValue(modeKey, out var modeDecl) || !modeDecl.WarningOnNoMatch)
+            return;
+        var what = node switch
+        {
+            XdmElement e => $"element {e.LocalName}",
+            XdmAttribute a => $"attribute {a.LocalName}",
+            XdmDocument => "document node",
+            XdmText => "text node",
+            XdmComment => "comment",
+            XdmProcessingInstruction => "processing instruction",
+            _ => "node",
+        };
+        var where = mode is { } m && m.LocalName.Length > 0 ? $" in mode {m.LocalName}" : "";
+        listener($"No template rule matches {what}{where}; the built-in rule was used");
     }
 
 

--- a/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StylesheetParser.Declarations.cs
@@ -2676,10 +2676,10 @@ public sealed partial class StylesheetParser
                     GetSourceLocation(element));
         }
 
-        // Validate warning-on-no-match (XTSE0020 for invalid values like "Yes")
+        // warning-on-no-match (XTSE0020 for invalid values like "Yes")
         var warningOnNoMatchAttr = element.Attribute("warning-on-no-match");
-        if (warningOnNoMatchAttr != null)
-            NormalizeYesNo(warningOnNoMatchAttr.Value.Trim(), "warning-on-no-match", "xsl:mode", element);
+        var warningOnNoMatch = warningOnNoMatchAttr != null
+            && NormalizeYesNo(warningOnNoMatchAttr.Value.Trim(), "warning-on-no-match", "xsl:mode", element);
 
         // Validate warning-on-multiple-match (XTSE0020 for invalid values like "Yes")
         var warningOnMultipleMatchAttr = element.Attribute("warning-on-multiple-match");
@@ -2703,6 +2703,7 @@ public sealed partial class StylesheetParser
         {
             Name = nameAttr != null ? ParseQName(nameAttr.Value, element) : null,
             Streamable = streamableAttr?.Value == "yes",
+            WarningOnNoMatch = warningOnNoMatch,
             OnNoMatch = onNoMatchAttr != null ? ParseOnNoMatchBehavior(onNoMatchAttr.Value, element) : null,
             OnMultipleMatch = onMultipleMatchAttr != null ? ParseOnMultipleMatchBehavior(onMultipleMatchAttr.Value, element) : OnMultipleMatchBehavior.UseLast,
             Visibility = ParseVisibility(visibilityAttr?.Value),

--- a/src/PhoenixmlDb.Xslt/Engine/XsltTransformOptions.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltTransformOptions.cs
@@ -130,6 +130,13 @@ public sealed class XsltTransformOptions
     public Action<string, bool>? MessageListener { get; init; }
 
     /// <summary>
+    /// Receives processor warnings — currently xsl:mode warning-on-no-match. A warning is a
+    /// diagnostic the transform continues past, so it has its own channel rather than sharing
+    /// xsl:message's.
+    /// </summary>
+    public Action<string>? WarningListener { get; init; }
+
+    /// <summary>
     /// Extended message listener that also receives source location.
     /// Receives (message, terminate, line, column). Takes precedence over <see cref="MessageListener"/>.
     /// </summary>

--- a/src/PhoenixmlDb.Xslt/XsltFacade.cs
+++ b/src/PhoenixmlDb.Xslt/XsltFacade.cs
@@ -755,6 +755,12 @@ public sealed class XsltTransformer
     public Action<string, bool>? MessageListener { get; set; }
 
     /// <summary>
+    /// Receives processor warnings — currently the xsl:mode warning-on-no-match diagnostic,
+    /// reported once per node processed with no matching template rule.
+    /// </summary>
+    public Action<string>? WarningListener { get; set; }
+
+    /// <summary>
     /// Extended listener for <c>xsl:message</c> that also receives source location (line, column).
     /// Takes precedence over <see cref="MessageListener"/> when set.
     /// </summary>
@@ -1158,6 +1164,7 @@ public sealed class XsltTransformer
             TraceListener = TraceListener,
             MessageListener = MessageListener,
             MessageListenerWithLocation = MessageListenerWithLocation,
+            WarningListener = WarningListener,
             ResourcePolicy = ResourcePolicy,
             PreloadedResources = PreloadedResources,
             ReturnRawXdm = rawBox != null,

--- a/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
+++ b/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
@@ -977,6 +977,7 @@ public sealed class XsltTestRunner
             }
 
             // Execute transformation with timeout protection
+            var warnings = new List<string>();
             var transformTask = Task.Run(async () =>
             {
                 // The W3C corpus is trusted local data and 12 of its stylesheets carry a
@@ -984,6 +985,9 @@ public sealed class XsltTestRunner
                 // DTDs unless asked — the right default for arbitrary input, wrong for a
                 // conformance run, which must parse what the suite actually ships.
                 var transformer = new XsltTransformer { AllowDtdProcessing = true };
+                // xsl:mode warning-on-no-match reports through this channel. Without collecting
+                // it, every assert-warning failed for want of anywhere to look.
+                transformer.WarningListener = w => { lock (warnings) warnings.Add(w); };
                 Uri? baseUri = testCase.Environment.StylesheetPath != null
                     ? new Uri(Path.GetFullPath(testCase.Environment.StylesheetPath))
                     : null;
@@ -1097,8 +1101,9 @@ public sealed class XsltTestRunner
             var (output, secondaryResults) = await transformTask.WaitAsync(cts.Token);
             result.ActualResult = output;
 
-            // Verify assertions (pass secondary results for assert-result-document)
-            result.Passed = await VerifyAssertionsAsync(testCase.Assertions, output, cts.Token, secondaryResults);
+            // Verify assertions (pass secondary results for assert-result-document, and the
+            // warnings the transform reported for assert-warning)
+            result.Passed = await VerifyAssertionsAsync(testCase.Assertions, output, cts.Token, secondaryResults, warnings);
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested && !ct.IsCancellationRequested)
         {
@@ -1121,11 +1126,12 @@ public sealed class XsltTestRunner
         List<XsltAssertion> assertions,
         string? actualResult,
         CancellationToken ct,
-        IReadOnlyDictionary<string, string>? secondaryResults = null)
+        IReadOnlyDictionary<string, string>? secondaryResults = null,
+        IReadOnlyList<string>? warnings = null)
     {
         foreach (var assertion in assertions)
         {
-            if (!await VerifyAssertionAsync(assertion, actualResult, ct, secondaryResults))
+            if (!await VerifyAssertionAsync(assertion, actualResult, ct, secondaryResults, warnings))
             {
                 return false;
             }
@@ -1137,7 +1143,8 @@ public sealed class XsltTestRunner
         XsltAssertion assertion,
         string? actualResult,
         CancellationToken ct,
-        IReadOnlyDictionary<string, string>? secondaryResults = null)
+        IReadOnlyDictionary<string, string>? secondaryResults = null,
+        IReadOnlyList<string>? warnings = null)
     {
         return assertion.Type switch
         {
@@ -1151,8 +1158,8 @@ public sealed class XsltTestRunner
             "assert-deep-eq" => VerifyDeepEq(assertion, actualResult),
             "assert-message" => true, // Message assertions require special handling
             "error" => false, // Expected error, but we got a result
-            "all-of" => await AllOfAsync(assertion.Children, actualResult, ct, secondaryResults),
-            "any-of" => await AnyOfAsync(assertion.Children, actualResult, ct, secondaryResults),
+            "all-of" => await AllOfAsync(assertion.Children, actualResult, ct, secondaryResults, warnings),
+            "any-of" => await AnyOfAsync(assertion.Children, actualResult, ct, secondaryResults, warnings),
 
             // <assert> is an XPath predicate over the result tree, and the single most common
             // assertion in the whole corpus — 11024 occurrences. It was unimplemented, so the
@@ -1161,7 +1168,7 @@ public sealed class XsltTestRunner
 
             // <not> negates its single child.
             "not" => assertion.Children.Count == 1
-                && !await VerifyAssertionAsync(assertion.Children[0], actualResult, ct, secondaryResults),
+                && !await VerifyAssertionAsync(assertion.Children[0], actualResult, ct, secondaryResults, warnings),
 
             "assert-empty" => string.IsNullOrWhiteSpace(actualResult),
 
@@ -1177,9 +1184,9 @@ public sealed class XsltTestRunner
             // and sweep are ever exposed by the analyser, implement it here.
             "assert-posture-and-sweep" => false,
 
-            // The test expects the transform to raise a warning. Warnings are not collected by
-            // this runner, so the same reasoning applies — 6 occurrences.
-            "assert-warning" => false,
+            // The test expects the transform to raise a warning. The runner collects them from
+            // the transformer's WarningListener; a test that asks for one and got none fails.
+            "assert-warning" => warnings is { Count: > 0 },
 
             // Serialization was expected to fail with a given code. The transform produced a
             // result instead, so it did not — 45 occurrences. (A transform that DOES throw is
@@ -1353,22 +1360,22 @@ public sealed class XsltTestRunner
     }
 
     private async Task<bool> AllOfAsync(List<XsltAssertion> assertions, string? result, CancellationToken ct,
-        IReadOnlyDictionary<string, string>? secondaryResults = null)
+        IReadOnlyDictionary<string, string>? secondaryResults = null, IReadOnlyList<string>? warnings = null)
     {
         foreach (var a in assertions)
         {
-            if (!await VerifyAssertionAsync(a, result, ct, secondaryResults))
+            if (!await VerifyAssertionAsync(a, result, ct, secondaryResults, warnings))
                 return false;
         }
         return true;
     }
 
     private async Task<bool> AnyOfAsync(List<XsltAssertion> assertions, string? result, CancellationToken ct,
-        IReadOnlyDictionary<string, string>? secondaryResults = null)
+        IReadOnlyDictionary<string, string>? secondaryResults = null, IReadOnlyList<string>? warnings = null)
     {
         foreach (var a in assertions)
         {
-            if (await VerifyAssertionAsync(a, result, ct, secondaryResults))
+            if (await VerifyAssertionAsync(a, result, ct, secondaryResults, warnings))
                 return true;
         }
         return false;

--- a/tests/PhoenixmlDb.Xslt.Tests/WarningOnNoMatchTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/WarningOnNoMatchTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// xsl:mode warning-on-no-match="yes" reports each node processed in that mode with no matching
+/// template rule, so an author can find what is falling through to the built-in rule. The
+/// attribute was parsed, validated and then dropped: it produced no diagnostic at all
+/// (W3C attr/mode mode-1427/1428/1440/1442).
+/// </summary>
+public sealed class WarningOnNoMatchTests
+{
+    private static async Task<(string Output, List<string> Warnings)> RunAsync(string modeAttributes)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="text"/>
+              <xsl:mode {modeAttributes}/>
+              <xsl:template match="known">seen</xsl:template>
+            </xsl:stylesheet>
+            """;
+        var warnings = new List<string>();
+        var t = new XsltTransformer { WarningListener = warnings.Add };
+        await t.LoadStylesheetAsync(ss);
+        var output = await t.TransformAsync("<doc><known/><unknown/></doc>");
+        return (output.Trim(), warnings);
+    }
+
+    [Theory]
+    [InlineData("""warning-on-no-match="yes" """)]
+    [InlineData("""warning-on-no-match="true" """)]
+    [InlineData("""warning-on-no-match="1" """)]
+    public async Task ANodeWithNoMatchingRule_IsReported(string modeAttributes)
+    {
+        var (_, warnings) = await RunAsync(modeAttributes);
+        warnings.Should().NotBeEmpty();
+        warnings.Should().Contain(w => w.Contains("No template rule matches", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("""warning-on-no-match="no" """)]
+    public async Task WithoutTheAttribute_NothingIsReported(string modeAttributes)
+        => (await RunAsync(modeAttributes)).Warnings.Should().BeEmpty();
+
+    /// <summary>The warning is a diagnostic: the transform runs to completion regardless.</summary>
+    [Fact]
+    public async Task TheTransformStillRuns()
+        => (await RunAsync("""warning-on-no-match="yes" """)).Output.Should().Be("seen");
+}


### PR DESCRIPTION
`xsl:mode warning-on-no-match="yes"` was parsed, validated for XTSE0020, and then **dropped**. The engine produced no diagnostic at all — the attribute did nothing.

It exists to answer the question the output cannot: *which nodes fell through to the built-in rule?* The built-in rule is quiet by design, so a node no template matched shows up as text appearing where the author expected markup, or as nothing at all.

- `XsltMode` carries the flag.
- A `WarningListener` on the transformer and transform options. A warning is a diagnostic the transform continues past, so it gets its own channel rather than sharing `xsl:message`'s (which also signals termination).
- Both sites that fall through to the built-in rule report, naming the node kind and the mode.

**The harness could not judge these tests either.** `assert-warning` returned `false` unconditionally with the comment "warnings are not collected by this runner" — honest, and it meant four W3C cases could never pass however the engine behaved. It now collects warnings from the transformer, and a test that asks for a warning and receives none still fails.

**Tests:** `WarningOnNoMatchTests`, 6 cases — the three lexical forms of "yes", controls that no attribute and `="no"` stay silent, and that the transform still completes (a warning is not an error). The three positive cases fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): mode-1427, mode-1428, mode-1440 and mode-1442 now pass; +4, no losses (call-template-1002 is a known flicker that fails on main too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn