### PR TITLE
A suppressed subtree does not close its ancestor

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/StreamingXmlProcessor.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/StreamingXmlProcessor.cs
@@ -800,7 +800,14 @@ internal sealed class StreamingXmlProcessor
                                 }
                             }
 
-                            // Check if we're closing a suppressed element
+                            // Check if we're closing a suppressed element — or anything INSIDE
+                            // one. A suppressed element's descendants wrote no open tag either,
+                            // so they must not pop the deferred-close stack: <v> suppressed by an
+                            // empty template still delivers EndElement for its <deity> child, and
+                            // that pop closed an ANCESTOR early — </book> landed after the first
+                            // chapter, with the rest of the document outside the root element
+                            // (W3C attr/mode mode-1416).
+                            var insideSuppressed = suppressionDepth >= 0 && closingContext.Depth > suppressionDepth;
                             var wasSuppressedElement = suppressionDepth >= 0 && closingContext.Depth == suppressionDepth;
                             if (wasSuppressedElement)
                                 suppressionDepth = -1;
@@ -839,7 +846,7 @@ internal sealed class StreamingXmlProcessor
 
                             // Write the deferred closing tag for elements opened by shallow-copy.
                             // Skip this for suppressed elements — they never wrote an open tag.
-                            if (!wasSuppressedElement && _context._streamingOpenElements.Count > 0)
+                            if (!wasSuppressedElement && !insideSuppressed && _context._streamingOpenElements.Count > 0)
                             {
                                 var qname = _context._streamingOpenElements.Pop();
                                 _context.WriteStreamingEndTag(qname);

--- a/tests/PhoenixmlDb.Xslt.Tests/StreamingSuppressedSubtreeTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/StreamingSuppressedSubtreeTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// A template with an empty body suppresses its element AND its subtree. Under streaming only the
+/// suppressed element itself was recognised at its end tag: its DESCENDANTS still popped the
+/// deferred-close stack, which closes an ancestor early — the root element ended after the first
+/// child that contained one, and the rest of the document followed outside it
+/// (W3C attr/mode mode-1416).
+/// </summary>
+public sealed class StreamingSuppressedSubtreeTests
+{
+    private const string Source = """
+        <book><chapter><title>One</title><v>text <deity>God</deity> more</v></chapter><chapter><title>Two</title></chapter></book>
+        """;
+
+    private static async Task<string> RunAsync(bool streamed)
+    {
+        var ss = """
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output method="xml" omit-xml-declaration="yes"/>
+              <xsl:mode on-no-match="shallow-copy" streamable="yes"/>
+              <xsl:template match="v"/>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return (streamed ? await t.TransformAsync(new StringReader(Source)) : await t.TransformAsync(Source)).Trim();
+    }
+
+    [Fact]
+    public async Task ASuppressedSubtree_DoesNotCloseAnAncestor()
+        => (await RunAsync(streamed: true))
+            .Should().Be("<book><chapter><title>One</title></chapter><chapter><title>Two</title></chapter></book>",
+                "a descendant of the suppressed <v> popped the deferred close, ending <book> early");
+
+    [Fact]
+    public async Task TheUnstreamedRunAgrees()
+        => (await RunAsync(streamed: true)).Should().Be(await RunAsync(streamed: false));
+}


### PR DESCRIPTION
A template with an empty body suppresses its element **and everything under it**. Under streaming, only the suppressed element itself was recognised at its end tag — its descendants still popped the deferred-close stack, and each pop wrote the closing tag of an enclosing element that was still open.

The output is malformed, not merely wrong:

```
<book><chapter><title>One</title></chapter></book><chapter><title>Two</title></chapter>
                                          ↑ root closed here, rest of the document outside it
```

Tracing the closes for W3C mode-1416 shows it plainly — `<v>` is suppressed by an empty template, and its `<deity>` child arrives at its end tag unsuppressed:

```
[end] v      d=2 suppressed=True   stack=book
[end] deity  d=3 suppressed=False  stack=book     ← pops "book"
```

Elements inside a suppressed subtree wrote no open tag, so they must not pop. The fix marks anything below the suppression depth, not just the element at it.

**Tests:** `StreamingSuppressedSubtreeTests` — the streamed result, and that it agrees with the unstreamed one. Fails on main with the second chapter outside the root.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): mode-1416 now passes — the last of the attr/mode family — plus call-template-1002, a known flicker, landing on the good side; +2 with zero per-set losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn