### PR TITLE
SESU0013 for an html version this processor cannot serialize

### DIFF
--- a/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
+++ b/src/PhoenixmlDb.Xslt/Engine/XsltTransformEngine.cs
@@ -698,8 +698,31 @@ public sealed class XsltTransformEngine
         return topElements == 1 && !topLevelText;
     }
 
+    /// <summary>
+    /// SESU0013: the html and xhtml output methods take a version this processor can actually
+    /// serialize — HTML 4.0/4.01/5 and XHTML 1.0/1.1/5. An unsupported one (version="0.0") was
+    /// accepted in silence and the result serialized as if nothing had been asked for, so a
+    /// stylesheet requesting a version we cannot produce got output that merely looked fine
+    /// (W3C decl/output output-0194).
+    /// </summary>
+    private static void RequireSupportedHtmlVersion(XsltOutput? outputDecl)
+    {
+        if (outputDecl?.Version is not { Length: > 0 } version
+            || outputDecl.EffectiveMethod is not (OutputMethod.Html or OutputMethod.Xhtml))
+            return;
+        if (!decimal.TryParse(version, System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            || parsed is not (1.0m or 1.1m or 4.0m or 4.01m or 5.0m))
+        {
+            throw new XsltException(
+                $"SESU0013: The {(outputDecl.EffectiveMethod == OutputMethod.Html ? "html" : "xhtml")} output method does not support version '{version}'");
+        }
+    }
+
+
     internal string FinalizeOutput(string output, XsltOutput? outputDecl, IReadOnlyList<QName>? resultDocCharacterMaps, FinalizeKind kind)
     {
+        RequireSupportedHtmlVersion(outputDecl);
         // Default output method (Serialization 4.0 §Default Output Method): when no method was
         // specified on xsl:output, a serialized result whose document element is `html` resolves to
         // the html method (html element in no namespace) or the xhtml method (html element in the

--- a/tests/PhoenixmlDb.Xslt.Tests/HtmlVersionSupportTests.cs
+++ b/tests/PhoenixmlDb.Xslt.Tests/HtmlVersionSupportTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using PhoenixmlDb.Xslt.Engine;
+using Xunit;
+
+namespace PhoenixmlDb.Xslt.Tests;
+
+/// <summary>
+/// SESU0013: the html and xhtml output methods take a version this processor can serialize. An
+/// unsupported one was accepted in silence and the result serialized as if nothing had been asked
+/// for, so a stylesheet requesting a version we cannot produce got output that merely looked fine
+/// (W3C decl/output output-0194).
+/// </summary>
+public sealed class HtmlVersionSupportTests
+{
+    private static async Task<string> RunAsync(string outputAttributes)
+    {
+        var ss = $"""
+            <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:output {outputAttributes}/>
+              <xsl:template match="/"><html><body>hello</body></html></xsl:template>
+            </xsl:stylesheet>
+            """;
+        var t = new XsltTransformer();
+        await t.LoadStylesheetAsync(ss);
+        return await t.TransformAsync("<doc/>");
+    }
+
+    [Theory]
+    [InlineData("""method="html" version="0.0" """)]
+    [InlineData("""method="html" version="3.2" """)]
+    [InlineData("""method="xhtml" version="2.0" """)]
+    public async Task AnUnsupportedVersion_IsSESU0013(string outputAttributes)
+    {
+        var act = () => RunAsync(outputAttributes);
+        (await act.Should().ThrowAsync<Exception>()).Which.Message.Should().Contain("SESU0013");
+    }
+
+    [Theory]
+    [InlineData("""method="html" version="4.0" """)]
+    [InlineData("""method="html" version="4.01" """)]
+    [InlineData("""method="html" version="5.0" """)]
+    [InlineData("""method="html" version="5" """)]
+    [InlineData("""method="xhtml" version="1.0" """)]
+    [InlineData("""method="xhtml" version="1.1" """)]
+    [InlineData("""method="html" """)]
+    [InlineData("""method="xml" version="1.0" """)]
+    public async Task ASupportedVersion_Serializes(string outputAttributes)
+        => (await RunAsync(outputAttributes)).Should().Contain("hello");
+}


### PR DESCRIPTION
`<xsl:output method="html" version="0.0"/>` was accepted in silence, and the result serialized as though nothing had been asked for. A stylesheet requesting a version the processor cannot produce got output that merely looked fine — the failure mode this codebase keeps producing.

The html and xhtml methods now raise SESU0013 for a version outside HTML 4.0/4.01/5 and XHTML 1.0/1.1/5. The `xml` method's `version` is untouched, and `html-version` (a separate attribute, already validated) is unaffected.

**On the size of this cluster.** It was flagged as ~45 `assert-serialization-error` cases that "run, assert and cannot pass". They can: **42 of the 43 already pass**, because their expectation is an `any-of` whose other branch is a static error the engine does raise (`XTSE0020` for a bad `byte-order-mark`, say). output-0194 is the only one that was failing, and it fails because of a missing check rather than a harness gap.

**Tests:** `HtmlVersionSupportTests`, 11 cases — three unsupported versions across both methods, and controls for every supported one plus no version at all and `method="xml" version="1.0"`. The three unsupported cases fail on main.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): output-0194 now passes; +1 with zero per-set losses (call-template-1002 is a known flicker, on the good side this run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn