### PR TITLE
scripts/ab-sweep.sh: the A/B procedure, with its preconditions checked

### DIFF
--- a/scripts/ab-sweep.sh
+++ b/scripts/ab-sweep.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Same-checkout A/B conformance sweep.
 #
-# Runs the suite twice from ONE checkout — once with src/ as it is on the base
-# branch, once with src/ as it is here — and reports the per-set difference in
+# Runs the suite twice from ONE checkout — once with the code as it is on the
+# base branch, once as it is here — and reports the per-set difference in
 # failing cases. One checkout means one corpus, one baseline and one machine
 # state, so a difference between the arms is the change and nothing else.
+#
+# Both src/ and tests/ are swapped: a harness change moves the numbers exactly
+# as an engine change does, and swapping only src/ would report a harness fix
+# as no change at all.
 #
 #   scripts/ab-sweep.sh                 # whole suite
 #   scripts/ab-sweep.sh insn misc       # named chunks only
@@ -29,8 +33,8 @@ OUT="${AB_OUT:-/tmp/ab-sweep-$$}"
 # and the run reports a flat, clean, meaningless result. A comparison that
 # cannot distinguish its two arms is not a weak measurement, it is not a
 # measurement.
-if git diff --quiet "$BASE" HEAD -- src; then
-  echo "A/B ABORT: src is identical to $BASE — the two arms would measure the same code." >&2
+if git diff --quiet "$BASE" HEAD -- src tests; then
+  echo "A/B ABORT: src and tests are identical to $BASE — the two arms would measure the same thing." >&2
   exit 2
 fi
 
@@ -60,10 +64,10 @@ run_arm() {  # $1 = arm name, rest = chunks
   CONFORMANCE_OUT="$OUT/$arm" ./scripts/conformance.sh ${*:-} > "$OUT/$arm.out" 2>&1
 }
 
-trap 'git checkout -q HEAD -- src' EXIT
-git checkout -q "$BASE" -- src
+trap 'git checkout -q HEAD -- src tests' EXIT
+git checkout -q "$BASE" -- src tests
 run_arm base "$@"
-git checkout -q HEAD -- src
+git checkout -q HEAD -- src tests
 run_arm change "$@"
 
 python3 - "$OUT/base" "$OUT/change" <<'PY'

--- a/scripts/ab-sweep.sh
+++ b/scripts/ab-sweep.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Same-checkout A/B conformance sweep.
+#
+# Runs the suite twice from ONE checkout — once with src/ as it is on the base
+# branch, once with src/ as it is here — and reports the per-set difference in
+# failing cases. One checkout means one corpus, one baseline and one machine
+# state, so a difference between the arms is the change and nothing else.
+#
+#   scripts/ab-sweep.sh                 # whole suite
+#   scripts/ab-sweep.sh insn misc       # named chunks only
+#
+# Env:
+#   AB_BASE   base to compare against (default origin/main)
+#   AB_OUT    directory for the two runs (default a scratch dir under /tmp)
+#
+# The two guards below exist because both of their failure modes are SILENT:
+# each produces a clean-looking result rather than an error, which is the one
+# thing a measurement must never do.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+BASE="${AB_BASE:-origin/main}"
+OUT="${AB_OUT:-/tmp/ab-sweep-$$}"
+
+# GUARD 1 — the arms must differ.
+# The usual procedure stashes src/ for the baseline arm, which moves nothing
+# when the change is already COMMITTED: both arms then measure identical code
+# and the run reports a flat, clean, meaningless result. A comparison that
+# cannot distinguish its two arms is not a weak measurement, it is not a
+# measurement.
+if git diff --quiet "$BASE" HEAD -- src; then
+  echo "A/B ABORT: src is identical to $BASE — the two arms would measure the same code." >&2
+  exit 2
+fi
+
+# GUARD 2 — the change must be somewhere it can ship from.
+# A commit made while sitting on an already-merged branch (or on main) looks
+# fine locally and is only noticed at push time, if then. On a branch that is
+# not yet merged it would ride out inside an unrelated PR.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "HEAD" ]; then
+  echo "A/B ABORT: on '$BRANCH' — commit the change to a working branch first." >&2
+  exit 2
+fi
+if git merge-base --is-ancestor HEAD "$BASE" 2>/dev/null; then
+  echo "A/B ABORT: '$BRANCH' is already merged into $BASE — new commits here ship inside an unrelated PR." >&2
+  exit 2
+fi
+
+mkdir -p "$OUT"
+echo "A/B: $BRANCH vs $BASE   chunks: ${*:-all}   out: $OUT"
+
+run_arm() {  # $1 = arm name, rest = chunks
+  local arm="$1"; shift
+  rm -rf "${OUT:?}/$arm"
+  # A stale runtimeconfig from a previous build changes strict-mode behaviour
+  # between arms; delete it so both arms build their own.
+  find . -path '*/bin/*' -name '*.runtimeconfig.json' -path '*Conformance*' -delete
+  CONFORMANCE_OUT="$OUT/$arm" ./scripts/conformance.sh ${*:-} > "$OUT/$arm.out" 2>&1
+}
+
+trap 'git checkout -q HEAD -- src' EXIT
+git checkout -q "$BASE" -- src
+run_arm base "$@"
+git checkout -q HEAD -- src
+run_arm change "$@"
+
+python3 - "$OUT/base" "$OUT/change" <<'PY'
+import glob, os, re, sys
+def failures(d):
+    out = {}
+    for f in glob.glob(os.path.join(d, '*.log')):
+        text = open(f, errors='replace').read()
+        out[os.path.basename(f)] = set(re.findall(r'FAILED: (\S+)', text))
+    return out
+base, change = failures(sys.argv[1]), failures(sys.argv[2])
+total = lambda d: sum(len(v) for v in d.values())
+print(f'base failures {total(base)}  change failures {total(change)}')
+moved = False
+for name in sorted(set(base) | set(change)):
+    lost = sorted(change.get(name, set()) - base.get(name, set()))
+    won = sorted(base.get(name, set()) - change.get(name, set()))
+    if lost or won:
+        moved = True
+        print(f'{name}  LOST {lost}  WON {won}')
+if not moved:
+    print('no per-set differences')
+PY


### PR DESCRIPTION
The same-checkout A/B sweep — stash `src`, run the suite, restore, run again, diff the failing sets per set — has been a habit rather than a script. It has two preconditions that nothing checks, and **both fail silently**: each produces a clean-looking result instead of an error, which is the one thing a measurement must never do.

**Guard 1 — the arms must differ.** Stashing `src` moves nothing when the change is already committed, so both arms measure identical code and the sweep reports a flat, zero-loss result indistinguishable from a genuine one. I hit this today and stopped the run only because the timing looked wrong.

**Guard 2 — the branch must be one the change can ship from.** A commit made while sitting on an already-merged branch, or on `main`, is caught at push time if at all. On an unmerged branch it rides out inside an unrelated PR. I hit this today too: the SESU0013 commit landed on the already-merged #62 branch.

Both now abort with an explanation. The script also deletes the stale `*.runtimeconfig.json` between arms — that one has twice produced phantom 25-case regressions.

Verified all four paths: guard 1 aborts on an unchanged `src`; guard 2 aborts on a detached HEAD and on an already-merged branch; and a real run completes and reports its per-set diff.

```
$ scripts/ab-sweep.sh insn
A/B: fix/... vs origin/main   chunks: insn   out: /tmp/ab-sweep-1443011
base failures 51  change failures 51
no per-set differences
```

No engine change — and running it on this branch correctly refuses, since `src` is identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn