### PR TITLE
The conformance runner loads the principal stylesheet, not the secondary one

### DIFF
--- a/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
+++ b/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
@@ -385,10 +385,20 @@ public sealed class XsltTestRunner
         var testElem = elem.Element(ns + "test");
         if (testElem != null)
         {
-            // File-based stylesheet via <stylesheet file="..."/> or <package file="..." role="principal"/>
-            var stylesheetElem = testElem.Element(ns + "stylesheet")
-                ?? testElem.Elements(ns + "package")
-                    .FirstOrDefault(p => p.Attribute("role")?.Value != "secondary");
+            // The principal stylesheet is whichever element SAYS it is principal, whether that is
+            // <package role="principal"/> or <stylesheet role="principal"/>; only then a
+            // <stylesheet> with no role, and only then an unmarked <package>. Preferring
+            // <stylesheet> outright loaded the SECONDARY import as the principal whenever a test
+            // paired a principal package with a secondary stylesheet, so eight decl/package cases
+            // ran the wrong file — package-015 ran its import, whose xsl:mode declares
+            // on-no-match="fail", and duly failed with XTDE0555 for a stylesheet that says
+            // text-only-copy.
+            static bool IsRole(XElement e, string role) => e.Attribute("role")?.Value == role;
+            var stylesheetElem = testElem.Elements()
+                    .FirstOrDefault(e => (e.Name == ns + "stylesheet" || e.Name == ns + "package")
+                        && IsRole(e, "principal"))
+                ?? testElem.Elements(ns + "stylesheet").FirstOrDefault(e => !IsRole(e, "secondary"))
+                ?? testElem.Elements(ns + "package").FirstOrDefault(e => !IsRole(e, "secondary"));
             if (stylesheetElem != null)
             {
                 var stylesheetFile = stylesheetElem.Attribute("file")?.Value;


### PR DESCRIPTION
Eight `decl/package` cases failed with `XTDE0555: No matching template found for document node in mode #unnamed with on-no-match='fail'` — for stylesheets that declare `on-no-match="text-only-copy"`.

**The runner was running the wrong file.** The principal stylesheet is whichever element says it is principal, and these tests declare both:

```xml
<test>
  <package    file="package-015.xsl"        role="principal"/>
  <stylesheet file="package-015-import.xsl" role="secondary"/>
</test>
```

The selection preferred any `<stylesheet>` element outright, so it loaded the **secondary import** as the principal. That import declares `<xsl:mode on-no-match="fail"/>`, which is exactly the error we saw. The engine was right the whole time: the same transform through the CLI produces the expected `Some random input file`.

Selection is now: an element marked `role="principal"` (either kind), then a `<stylesheet>` not marked secondary, then a `<package>` not marked secondary.

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`, swapping `tests/`): package-015, 019, 020, 021, 022, 910, 913, 913a and 913b now pass; +9 with zero per-set losses (call-template-1002 is a known flicker).

Nine more cases that were never testing the engine — the ninth instance today of a green-or-red result that measured something other than what it claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn