### PR TITLE
The runner honours a test's package-version resolution policy

### DIFF
--- a/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
+++ b/tests/PhoenixmlDb.Conformance.Tests/Xslt/XsltTestRunner.cs
@@ -1007,7 +1007,19 @@ public sealed class XsltTestRunner
                 var packageCatalog = testCase.Environment.Packages.Count > 0
                     ? testCase.Environment.Packages
                     : null;
-                await transformer.LoadStylesheetAsync(stylesheetContent, baseUri, staticParams, packageCatalog);
+                // A test may ask for a particular package-version resolution policy
+                // (<package_version_resolution value="lowest_version"/>). The engine takes that
+                // as a load option; the runner never passed it, so those cases ran under the
+                // default (highest) and reported the version they asked us NOT to choose.
+                var versionResolution = testCase.Dependencies
+                    .FirstOrDefault(d => d.Type == "package_version_resolution")?.Value switch
+                {
+                    "lowest_version" => PackageVersionResolution.Lowest,
+                    "unspecified" => PackageVersionResolution.Unspecified,
+                    _ => PackageVersionResolution.Highest,
+                };
+                await transformer.LoadStylesheetAsync(stylesheetContent, baseUri, staticParams, packageCatalog,
+                    versionResolution);
 
                 // Set parameters (evaluate select expressions to get typed values)
                 foreach (var (name, selectExpr) in testCase.Environment.Parameters)


### PR DESCRIPTION
A test may state which package-version resolution policy it assumes:

```xml
<dependencies>
  <package_version_resolution value="lowest_version" satisfied="true"/>
</dependencies>
```

The engine takes that as a load option and has all along. **The runner never passed it**, so those cases ran under the default (highest) and reported the version they had explicitly asked us not to choose — use-package-203b wants `1.0.0` from `{1.0.0, 2.0.0}` and got `2.0.0`.

That is the third catalog input this audit has found unsupplied, after the base output URI (#58's neighbour) and the principal-vs-secondary role (#65).

**Conformance** (pinned, XQuery 1.7.0, same-checkout A/B over `--all`): use-package-203b, 204b, 206b and 210b now pass; +4 with zero per-set losses.

**On the wider audit, since it is now finished for this corpus:** I enumerated every element appearing inside `<test>` and `<environment>` and grepped the runner for each. Nineteen catalog inputs are never read — but measured against current failures, all nineteen together account for about twenty failing cases, and seven of them have every declaring case passing anyway. Frequency did not predict value: this input appears in 12 cases and was worth +4, while `schema` appears in 792 and is worth 9, all schema-aware. Nobody should read "19 unread inputs" as 19 opportunities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFzQJEPHoRxrjH6bni8tVn